### PR TITLE
Javascript and unittest fixes

### DIFF
--- a/django/publicmapping/redistricting/static/js/chooseplan.js
+++ b/django/publicmapping/redistricting/static/js/chooseplan.js
@@ -127,7 +127,7 @@ chooseplan = function(options) {
      */
     var selectPlan = function () {
         // Notify the reaggregator of reaggregation button clicks
-        if (db_util.startsWith($('#start_mapping .ui-button-text').html(), 'Reaggregate')) {
+        if (DB.util.startsWith($('#start_mapping .ui-button-text').html(), 'Reaggregate')) {
             _reaggregator.reaggregateClicked(_selectedPlanId);
             return;
         }
@@ -200,7 +200,7 @@ chooseplan = function(options) {
                         // if the content is text/html, redirect to '/',
                         // since we probably just got logged out from 
                         // another session
-                        if (db_util.startsWith(contentType, 'text/html')) {
+                        if (DB.util.startsWith(contentType, 'text/html')) {
                             window.location.href='/?msg=logoff';
                         }
                     },
@@ -483,7 +483,7 @@ chooseplan = function(options) {
 
         // workaround for problem with jqGrid custom formatter with boolean (is_shared)
         var shared = $('#is_shared');
-        if (db_util.contains(shared.val(), "unshared")) {
+        if (DB.util.contains(shared.val(), "unshared")) {
             shared.val(gettext('No'));
         } else {
             shared.val(gettext('Yes'));
@@ -659,7 +659,7 @@ chooseplan = function(options) {
         _cancelButton.button().click( function() {
             _table.jqGrid('GridToForm', _selectedPlanId, '#plan_form'); 
             var shared = $('#is_shared');
-            if (db_util.contains(shared.val(), "unshared")) {
+            if (DB.util.contains(shared.val(), "unshared")) {
                 shared.val(gettext('No'));
             } else {
                 shared.val(gettext('Yes'));

--- a/django/publicmapping/redistricting/static/js/chooseplan.js
+++ b/django/publicmapping/redistricting/static/js/chooseplan.js
@@ -127,7 +127,7 @@ chooseplan = function(options) {
      */
     var selectPlan = function () {
         // Notify the reaggregator of reaggregation button clicks
-        if ($('#start_mapping .ui-button-text').html().startsWith(gettext('Reaggregate'))) {
+        if (db_util.startsWith($('#start_mapping .ui-button-text').html(), 'Reaggregate')) {
             _reaggregator.reaggregateClicked(_selectedPlanId);
             return;
         }
@@ -200,7 +200,7 @@ chooseplan = function(options) {
                         // if the content is text/html, redirect to '/',
                         // since we probably just got logged out from 
                         // another session
-                        if (contentType.startsWith('text/html')) {
+                        if (db_util.startsWith(contentType, 'text/html')) {
                             window.location.href='/?msg=logoff';
                         }
                     },
@@ -483,7 +483,7 @@ chooseplan = function(options) {
 
         // workaround for problem with jqGrid custom formatter with boolean (is_shared)
         var shared = $('#is_shared');
-        if (shared.val().contains("unshared")) {
+        if (db_util.contains(shared.val(), "unshared")) {
             shared.val(gettext('No'));
         } else {
             shared.val(gettext('Yes'));
@@ -659,7 +659,7 @@ chooseplan = function(options) {
         _cancelButton.button().click( function() {
             _table.jqGrid('GridToForm', _selectedPlanId, '#plan_form'); 
             var shared = $('#is_shared');
-            if (shared.val().contains("unshared")) {
+            if (db_util.contains(shared.val(), "unshared")) {
                 shared.val(gettext('No'));
             } else {
                 shared.val(gettext('Yes'));

--- a/django/publicmapping/redistricting/static/js/layerchooser.js
+++ b/django/publicmapping/redistricting/static/js/layerchooser.js
@@ -109,7 +109,7 @@ layerchooser = function(options) {
 
             // See if we need to display the labels checkbox. This should only
             // be displayed if the reference layer is a plan.
-            _options.referenceLayerLabelsWrapper.toggle(selector.val().startsWith("plan"))
+            _options.referenceLayerLabelsWrapper.toggle(db_util.startsWith(selector.val(), "plan"))
         });
 
         // Trigger event when the show reference layer labels checkbox changes

--- a/django/publicmapping/redistricting/static/js/layerchooser.js
+++ b/django/publicmapping/redistricting/static/js/layerchooser.js
@@ -109,7 +109,7 @@ layerchooser = function(options) {
 
             // See if we need to display the labels checkbox. This should only
             // be displayed if the reference layer is a plan.
-            _options.referenceLayerLabelsWrapper.toggle(db_util.startsWith(selector.val(), "plan"))
+            _options.referenceLayerLabelsWrapper.toggle(DB.util.startsWith(selector.val(), "plan"))
         });
 
         // Trigger event when the show reference layer labels checkbox changes

--- a/django/publicmapping/redistricting/static/js/mapping.js
+++ b/django/publicmapping/redistricting/static/js/mapping.js
@@ -509,7 +509,7 @@ function mapinit(srs,maxExtent) {
         }
 
         var urlSuffix = '';
-        if (referenceLayerId.startsWith('plan')) {
+        if (db_util.startsWith(referenceLayerId, 'plan')) {
             urlSuffix = 'plan/' + referenceLayerId.substring('plan.'.length);
         } else {
             urlSuffix = 'geolevel/' + referenceLayerId.substring('geolevel.'.length);
@@ -2376,7 +2376,7 @@ function mapinit(srs,maxExtent) {
             }
             vislayers = olmap.getLayersBy('visibility',true);
             for (var i = 0; i < vislayers.length; i++ ) {
-                if (vislayers[i].name.startsWith(NAMESPACE)) {
+                if (db_util.startsWith(vislayers[i].name, NAMESPACE)) {
                     vislayers = vislayers[i].name;
                     break;
                 }

--- a/django/publicmapping/redistricting/static/js/mapping.js
+++ b/django/publicmapping/redistricting/static/js/mapping.js
@@ -509,7 +509,7 @@ function mapinit(srs,maxExtent) {
         }
 
         var urlSuffix = '';
-        if (db_util.startsWith(referenceLayerId, 'plan')) {
+        if (DB.util.startsWith(referenceLayerId, 'plan')) {
             urlSuffix = 'plan/' + referenceLayerId.substring('plan.'.length);
         } else {
             urlSuffix = 'geolevel/' + referenceLayerId.substring('geolevel.'.length);
@@ -2376,7 +2376,7 @@ function mapinit(srs,maxExtent) {
             }
             vislayers = olmap.getLayersBy('visibility',true);
             for (var i = 0; i < vislayers.length; i++ ) {
-                if (db_util.startsWith(vislayers[i].name, NAMESPACE)) {
+                if (DB.util.startsWith(vislayers[i].name, NAMESPACE)) {
                     vislayers = vislayers[i].name;
                     break;
                 }

--- a/django/publicmapping/redistricting/static/js/splitsreport.js
+++ b/django/publicmapping/redistricting/static/js/splitsreport.js
@@ -126,7 +126,7 @@ splitsreport = function(options) {
             }
       
             // Only add the option if it hasn't already been added, and is a plan
-            if (db_util.startsWith(rid, 'plan') && (_options.availableLayers.find('input[id=' + rid.replace('.', '\\.') + ']').length === 0)) {
+            if (DB.util.startsWith(rid, 'plan') && (_options.availableLayers.find('input[id=' + rid.replace('.', '\\.') + ']').length === 0)) {
                 // Clear out the old plans first
                 _options.availableLayers.find('input[value*=plan]').each( function() { $(this).parent().remove(); });
                 

--- a/django/publicmapping/redistricting/static/js/splitsreport.js
+++ b/django/publicmapping/redistricting/static/js/splitsreport.js
@@ -126,7 +126,7 @@ splitsreport = function(options) {
             }
       
             // Only add the option if it hasn't already been added, and is a plan
-            if (rid.startsWith('plan') && (_options.availableLayers.find('input[id=' + rid.replace('.', '\\.') + ']').length === 0)) {
+            if (db_util.startsWith(rid, 'plan') && (_options.availableLayers.find('input[id=' + rid.replace('.', '\\.') + ']').length === 0)) {
                 // Clear out the old plans first
                 _options.availableLayers.find('input[value*=plan]').each( function() { $(this).parent().remove(); });
                 

--- a/django/publicmapping/redistricting/static/js/utils.js
+++ b/django/publicmapping/redistricting/static/js/utils.js
@@ -4,10 +4,11 @@
 /* DistrictBuilder Javascript Utilities used in multiple
  * Javascript files in the DistrictBuilder codebase.
  * 
- * Instantiate db_util object to protect global namespace
+ * Instantiate DB object to protect global namespace
  */
 
-var db_util = {};
+var DB = {};
+DB.util = {};
 
 /* Checks whether a string starts with a substring 
  *
@@ -16,7 +17,7 @@ var db_util = {};
  *   substring -- characters to check if s starts with
  */
 
-db_util.startsWith = function(s, substring) {
+DB.util.startsWith = function(s, substring) {
     return (s.indexOf(substring) == 0);
 }
 
@@ -27,6 +28,6 @@ db_util.startsWith = function(s, substring) {
  *   substring -- characters to check if s contains
  */
 
-db_util.contains = function(s, substring) {
+DB.util.contains = function(s, substring) {
     return (s.indexOf(substring) != -1);
 };

--- a/django/publicmapping/redistricting/static/js/utils.js
+++ b/django/publicmapping/redistricting/static/js/utils.js
@@ -1,0 +1,32 @@
+
+/* DistrictBuilder Javascript Utilities */
+
+/* DistrictBuilder Javascript Utilities used in multiple
+ * Javascript files in the DistrictBuilder codebase.
+ * 
+ * Instantiate db_util object to protect global namespace
+ */
+
+var db_util = {};
+
+/* Checks whether a string starts with a substring 
+ *
+ * Parameters:
+ *   s -- string to compare
+ *   substring -- characters to check if s starts with
+ */
+
+db_util.startsWith = function(s, substring) {
+    return (s.indexOf(substring) == 0);
+}
+
+/* Checks whether a string contains a given substring 
+ *
+ * Parameters:
+ *   s -- string to compare
+ *   substring -- characters to check if s contains
+ */
+
+db_util.contains = function(s, substring) {
+    return (s.indexOf(substring) != -1);
+};

--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -82,6 +82,7 @@
     Load internal javascript logic.
 
     {% endcomment %}
+    <script type="text/javascript" src="/static-media/js/utils.js"></script>
     <script type="text/javascript" src="/static-media/js/ui.js"></script>
     <script type="text/javascript" src="/static-media/js/viewablesorter.js"></script>
     <script type="text/javascript" src="/static-media/js/mapping.js"></script>

--- a/django/publicmapping/redistricting/tests.py
+++ b/django/publicmapping/redistricting/tests.py
@@ -2817,7 +2817,7 @@ class CalculatorTestCase(BaseTestCase):
         calc = ConvexHull()
         calc.compute(district=district1)
         
-        self.assertEqual(0.012345679012345678, calc.result['value'])
+        self.assertAlmostEqual(0.012345679012345678, calc.result['value'], places=9)
 
     def test_convexhull_l2(self):
         """
@@ -2833,7 +2833,7 @@ class CalculatorTestCase(BaseTestCase):
         calc = ConvexHull()
         calc.compute(district=district1)
         
-        self.assertEqual(0.1111111111111111, calc.result['value'])
+        self.assertAlmostEqual(0.1111111111111111, calc.result['value'], places=9)
 
     def test_convexhull_row(self):
         """
@@ -2851,7 +2851,7 @@ class CalculatorTestCase(BaseTestCase):
         
         # 9 contiguous geounits at the middle level have the same area as one
         # geounit at the biggest level
-        self.assertEqual(0.1111111111111111, calc.result['value'])
+        self.assertAlmostEqual(0.1111111111111111, calc.result['value'], places=9)
 
     def test_convexhull_block(self):
         """
@@ -2869,7 +2869,7 @@ class CalculatorTestCase(BaseTestCase):
         
         # 9 contiguous geounits at the middle level have the same area as one
         # geounit at the biggest level
-        self.assertEqual(0.1111111111111111, calc.result['value'])
+        self.assertAlmostEqual(0.1111111111111111, calc.result['value'], places=9)
 
     def test_convexhull_column(self):
         """
@@ -2889,7 +2889,7 @@ class CalculatorTestCase(BaseTestCase):
         
         # 9 contiguous geounits at the middle level have the same area as one
         # geounit at the biggest level
-        self.assertEqual(0.1111111111111111, calc.result['value'])
+        self.assertAlmostEqual(0.1111111111111111, calc.result['value'], places=9)
 
     def test_convexhull_sparse(self):
         """
@@ -2924,7 +2924,7 @@ class CalculatorTestCase(BaseTestCase):
         
         # the average convex hull that covers this plan is the same as the 
         # district convex hull
-        self.assertEqual(0.1111111111111111, calc.result['value'])
+        self.assertAlmostEqual(0.1111111111111111, calc.result['value'], places=9)
 
     def test_convexhull_avg2(self):
         """
@@ -2946,7 +2946,7 @@ class CalculatorTestCase(BaseTestCase):
         
         # the average convex hull that covers this plan is the same as the 
         # district convex hull (both of them!)
-        self.assertEqual(0.1111111111111111, calc.result['value'])
+        self.assertAlmostEqual(0.1111111111111111, calc.result['value'], places=9)
 
 
 

--- a/django/publicmapping/redistricting/tests.py
+++ b/django/publicmapping/redistricting/tests.py
@@ -3036,8 +3036,8 @@ class ScoreRenderTestCase(BaseTestCase):
             markup = panel.render([self.plan,self.plan2])
             expected = 'testPlan:<span>9</span>' + \
                 'testPlan2:<span>9</span>' + \
-                'testPlan:<span>18.18%</span>' + \
-                'testPlan2:<span>10.64%</span>'
+                'testPlan:18.18%' + \
+                'testPlan2:10.64%'
                 
             self.assertEqual(expected, markup, 'The markup was incorrect. (e:"%s", a:"%s")' % (expected, markup))
 
@@ -3108,8 +3108,8 @@ class ScoreRenderTestCase(BaseTestCase):
 
         markup = display.render(plans)
 
-        expected = 'testPlan2:<span>10.64%</span>' + \
-            'testPlan:<span>18.18%</span>' + \
+        expected = 'testPlan2:10.64%' + \
+            'testPlan:18.18%' + \
             'testPlan:<span>9</span>' + \
             'testPlan2:<span>9</span>'
         self.assertEqual(expected, markup, 'The markup was incorrect. (e:"%s", a:"%s")' % (expected, markup))
@@ -3173,7 +3173,7 @@ class ScoreRenderTestCase(BaseTestCase):
         components = [(panel, [(function, arg1, arg2)])]
         district_result = display.render([self.district1], components=components)
         expected = 'District 1:<span>5</span>'
-        self.assertEqual(expected, district_result, 'Didn\'t get expected result when overriding district\'s display')
+        self.assertEqual(expected, district_result, 'Didn\'t get expected result when overriding district\'s display (e:"%s", a:"%s")' % (expected, district_result))
 
         os.remove(tplfile)
 
@@ -3202,8 +3202,8 @@ class ScoreRenderTestCase(BaseTestCase):
 
         # Check the result
         plan_result = display.render(self.plan, components=components)
-        expected = "testPlan:['<span>24</span>']"
-        self.assertEqual(expected, plan_result, 'Didn\'t get expected result when overriding plan\'s display')
+        expected = "testPlan:[u'<span>24</span>']"
+        self.assertEqual(expected, plan_result, 'Didn\'t get expected result when overriding plan\'s display (e: "%s", a:"%s")' % (expected, plan_result))
 
         os.remove(tplfile)
 


### PR DESCRIPTION
This pull request fixes #436 by creating a new Javascript utility file that implements the string methods `contains` and `startsWith` that were broken after an OpenLayers upgrade. Additionally, it replaces uses of these methods in Javascript files.

Finally, unittests were failing due to 2 minor issues and were fixed:
1. Float comparisons now use `assertAlmostEqual` instead of `assertEqual`
2. Template tests were failing due to some changes in html by designers, these were modified
