### PR TITLE
Make most setup script flags work

### DIFF
--- a/django/publicmapping/Dockerfile
+++ b/django/publicmapping/Dockerfile
@@ -4,14 +4,14 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY requirements.txt /usr/src/app/
-RUN apt-get update && apt-get install -y git gcc
+RUN apt-get update && apt-get install -y \
+    git gcc wget unzip
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /usr/src/app
 
 WORKDIR /usr/src/app
 
-RUN cp config/config.dist.xml config/config.xml \
-    && python setup.py ./config/config.xsd ./config/config.xml -v2 -d
+RUN cp config/config.dist.xml config/config.xml
 
 ENTRYPOINT ["/usr/local/bin/gunicorn"]

--- a/django/publicmapping/config/config.dist.xml
+++ b/django/publicmapping/config/config.dist.xml
@@ -1018,7 +1018,7 @@
           
           -->
 
-          <Shapefile path="/projects/PublicMapping/local/data/tl_2010_51_block10_3785_join.shp">
+          <Shapefile path="/data/tl_2010_51_block10_3785_join.shp">
               <Fields>
                   <!-- 
 
@@ -1079,7 +1079,7 @@
           
           -->
           <Files>
-              <Geography path="/projects/PublicMapping/local/data/tl_2010_51_vtd10_3785.shp">
+              <Geography path="/data/tl_2010_51_vtd10_3785.shp">
                   <!-- 
 
                   Each Field item defines a field in the shapefile that
@@ -1133,7 +1133,7 @@
           
           -->
           <Files>
-              <Geography path="/projects/PublicMapping/local/data/tl_2010_51_county10_3785.shp">
+              <Geography path="/data/tl_2010_51_county10_3785.shp">
                   <!-- 
 
                   Each Field item defines a field in the shapefile that
@@ -1185,19 +1185,19 @@
             unit of geography, and 2) the district it belongs to.
             
             -->
-            <Blockfile path="/projects/PublicMapping/local/data/cd111_index.csv" />
+            <Blockfile path="/data/cd111_index.csv" />
         </Template>
         
         <Template name="State House">
             <LegislativeBody ref="house"/>
             
-            <Blockfile path="/projects/PublicMapping/local/data/sldl10_index.csv" />
+            <Blockfile path="/data/sldl10_index.csv" />
         </Template>
 
         <Template name="State Senate">
             <LegislativeBody ref="senate"/>
 
-            <Blockfile path="/projects/PublicMapping/local/data/sldu10_index.csv" />
+            <Blockfile path="/data/sldu10_index.csv" />
         </Template>
     </Templates>
     
@@ -1324,7 +1324,7 @@
             <BardConfigs>
                 <BardConfig 
                     id="tenpercent"
-                    shape="/projects/PublicMapping/local/data/vablock_bard_save.Rdata" 
+                    shape="/data/vablock_bard_save.Rdata" 
                     temp="/projects/PublicMapping/local/reports"
                     transform="/projects/PublicMapping/DistrictBuilder/docs/bard_template.xslt">
                     <PopVars>
@@ -1357,7 +1357,7 @@
                 </BardConfig>
                 <BardConfig 
                     id="fivepercent"
-                    shape="/projects/PublicMapping/local/data/vablock_bard_save.Rdata" 
+                    shape="/data/vablock_bard_save.Rdata" 
                     temp="/projects/PublicMapping/local/reports"
                     transform="/projects/PublicMapping/DistrictBuilder/docs/bard_template.xslt">
                     <PopVars>

--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -1018,7 +1018,7 @@
           
           -->
 
-          <Shapefile path="/projects/PublicMapping/local/data/tl_2010_51_block10_3785_join.shp">
+          <Shapefile path="/data/tl_2010_51_block10_3785_join.shp">
               <Fields>
                   <!-- 
 
@@ -1079,7 +1079,7 @@
           
           -->
           <Files>
-              <Geography path="/projects/PublicMapping/local/data/tl_2010_51_vtd10_3785.shp">
+              <Geography path="/data/tl_2010_51_vtd10_3785.shp">
                   <!-- 
 
                   Each Field item defines a field in the shapefile that
@@ -1133,7 +1133,7 @@
           
           -->
           <Files>
-              <Geography path="/projects/PublicMapping/local/data/tl_2010_51_county10_3785.shp">
+              <Geography path="/data/tl_2010_51_county10_3785.shp">
                   <!-- 
 
                   Each Field item defines a field in the shapefile that
@@ -1185,19 +1185,19 @@
             unit of geography, and 2) the district it belongs to.
             
             -->
-            <Blockfile path="/projects/PublicMapping/local/data/cd111_index.csv" />
+            <Blockfile path="/data/cd111_index.csv" />
         </Template>
         
         <Template name="State House">
             <LegislativeBody ref="house"/>
             
-            <Blockfile path="/projects/PublicMapping/local/data/sldl10_index.csv" />
+            <Blockfile path="/data/sldl10_index.csv" />
         </Template>
 
         <Template name="State Senate">
             <LegislativeBody ref="senate"/>
 
-            <Blockfile path="/projects/PublicMapping/local/data/sldu10_index.csv" />
+            <Blockfile path="/data/sldu10_index.csv" />
         </Template>
     </Templates>
     
@@ -1324,7 +1324,7 @@
             <BardConfigs>
                 <BardConfig 
                     id="tenpercent"
-                    shape="/projects/PublicMapping/local/data/vablock_bard_save.Rdata" 
+                    shape="/data/vablock_bard_save.Rdata" 
                     temp="/projects/PublicMapping/local/reports"
                     transform="/projects/PublicMapping/DistrictBuilder/docs/bard_template.xslt">
                     <PopVars>
@@ -1357,7 +1357,7 @@
                 </BardConfig>
                 <BardConfig 
                     id="fivepercent"
-                    shape="/projects/PublicMapping/local/data/vablock_bard_save.Rdata" 
+                    shape="/data/vablock_bard_save.Rdata" 
                     temp="/projects/PublicMapping/local/reports"
                     transform="/projects/PublicMapping/DistrictBuilder/docs/bard_template.xslt">
                     <PopVars>

--- a/django/publicmapping/locale/en/LC_MESSAGES/xmlconfig.po
+++ b/django/publicmapping/locale/en/LC_MESSAGES/xmlconfig.po
@@ -2,7 +2,7 @@
 # Copyright (C) 2012
 # This file is distributed under the same license as the DistrictBuilder package.
 # David Zwarg <dzwarg@azavea.com>, 2012.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
@@ -12,11 +12,10 @@ msgstr ""
 "PO-Revision-Date: 2012-10-02 20:58+0000\n"
 "Last-Translator: David Zwarg <dzwarg@azavea.com>\n"
 "Language-Team: Azavea <info@azavea.com>\n"
-"Language: English\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:10
 msgid "congress short label"
@@ -32,7 +31,7 @@ msgstr "Congressional"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:10
 msgid "congress members"
-msgstr "districts"
+msgstr "Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:16
 msgid "community short label"
@@ -48,7 +47,7 @@ msgstr "Community Map"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:16
 msgid "community members"
-msgstr "communities"
+msgstr "Communities"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:853
 msgid "congress_leader_all short label"
@@ -85,8 +84,8 @@ msgstr "Equal Population"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:443
 msgid "plan_equivalence long description"
 msgstr ""
-"The Equipopulation score is the difference between the district with "
-"the highest population and the district with the lowest population."
+"The Equipopulation score is the difference between the district with the "
+"highest population and the district with the lowest population."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:688
 msgid "panel_compact_all short label"
@@ -111,10 +110,9 @@ msgstr "Average Compactness"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:505
 msgid "plan_schwartzberg long description"
 msgstr ""
-"The competition is using the 'Inverse Schwartzberg' compactness "
-"measure. This measure is a ratio of the circumference of the circle "
-"whose area is equal to the area of the district to the perimeter of "
-"the district."
+"The competition is using the 'Inverse Schwartzberg' compactness measure. "
+"This measure is a ratio of the circumference of the circle whose area is "
+"equal to the area of the district to the perimeter of the district."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:860
 msgid "congress_leader_mine short label"
@@ -199,8 +197,7 @@ msgstr "Target Pop. (727,366)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:373
 msgid "a_congress_plan_equipopulation_summary long description"
 msgstr ""
-"The population of each Congressional district must be 727,366 +/- "
-"0.5%."
+"The population of each Congressional district must be 727,366 +/- 0.5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:291
 msgid "b_plan_congress_noncontiguous short label"
@@ -537,8 +534,7 @@ msgstr "Count Districts"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:342
 msgid "a_congress_plan_count_districts long description"
 msgstr ""
-"The number of districts in a Congressional redistricting plan must be "
-"11."
+"The number of districts in a Congressional redistricting plan must be 11."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:363
 msgid "a_congress_plan_equipopulation_validation short label"
@@ -551,8 +547,7 @@ msgstr "Target Pop. (727,366)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:363
 msgid "a_congress_plan_equipopulation_validation long description"
 msgstr ""
-"The population of each Congressional district must be 727,366 +/- "
-"0.5%."
+"The population of each Congressional district must be 727,366 +/- 0.5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:423
 msgid "plan_all_blocks_assigned short label"
@@ -577,12 +572,12 @@ msgstr "All Contiguous"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:429
 msgid "plan_all_contiguous long description"
 msgstr ""
-"Contiguity means that every part of a district must be reachable from "
-"every other part without crossing the district's borders. All "
-"districts within a plan must be contiguous. Water contiguity is "
-"permitted given Virginia's extensive coastal region. 'Point "
-"contiguity' or 'touch-point contiguity' where two sections of a "
-"district are connected at a single point is not permitted."
+"Contiguity means that every part of a district must be reachable from every "
+"other part without crossing the district's borders. All districts within a "
+"plan must be contiguous. Water contiguity is permitted given Virginia's "
+"extensive coastal region. 'Point contiguity' or 'touch-point contiguity' "
+"where two sections of a district are connected at a single point is not "
+"permitted."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:969
 msgid "congress-equipop short label"
@@ -596,8 +591,8 @@ msgstr "Equipopulation - Congress"
 msgid "congress-equipop long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Equipopulation:</p><p>The population of each Congressional district "
-"must be 727,366 +/- 0.5%.</p>"
+"Equipopulation:</p><p>The population of each Congressional district must be "
+"727,366 +/- 0.5%.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:973
 msgid "congress-contiguous short label"
@@ -611,12 +606,11 @@ msgstr "AllContiguous - Congress"
 msgid "congress-contiguous long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Contiguity</p><p>Every part of a district must be reachable from every"
-" other part without crossing the district's borders. All districts "
-"within a plan must be contiguous. Water contiguity is permitted given "
-"Virginia's extensive coastal region. 'Point contiguity' or 'touch-"
-"point contiguity' where two sections of a district are connected at a "
-"single point is not permitted.</p>"
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:979
 msgid "congress-district-count short label"
@@ -857,3 +851,1338 @@ msgstr "municipality"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:28
 msgid "mx_municipio long description"
 msgstr "Municipality"
+
+#: /usr/src/app/config/config.xml:27
+msgid "va short label"
+msgstr "va"
+
+#: /usr/src/app/config/config.xml:27
+msgid "va label"
+msgstr "Virginia"
+
+#: /usr/src/app/config/config.xml:27
+msgid "va long description"
+msgstr "The Commonwealth of Virginia"
+
+#: /usr/src/app/config/config.xml:45
+msgid "dc short label"
+msgstr "dc"
+
+#: /usr/src/app/config/config.xml:45
+msgid "dc label"
+msgstr "DC Metro"
+
+#: /usr/src/app/config/config.xml:45
+msgid "dc long description"
+msgstr "The District of Columbia Metropolitan Area"
+
+#: /usr/src/app/config/config.xml:12
+msgid "house short label"
+msgstr "%(district_id)s"
+
+#: /usr/src/app/config/config.xml:12
+msgid "house label"
+msgstr "District %(district_id)s"
+
+#: /usr/src/app/config/config.xml:12
+msgid "house long description"
+msgstr "State House"
+
+#: /usr/src/app/config/config.xml:12
+msgid "house members"
+msgstr "Districts"
+
+#: /usr/src/app/config/config.xml:14
+msgid "senate short label"
+msgstr "%(district_id)s"
+
+#: /usr/src/app/config/config.xml:14
+msgid "senate label"
+msgstr "District %(district_id)s"
+
+#: /usr/src/app/config/config.xml:14
+msgid "senate long description"
+msgstr "State Senate"
+
+#: /usr/src/app/config/config.xml:14
+msgid "senate members"
+msgstr "Districts"
+
+#: /usr/src/app/config/config.xml:18
+msgid "dc_area_council short label"
+msgstr "%(district_id)s"
+
+#: /usr/src/app/config/config.xml:18
+msgid "dc_area_council label"
+msgstr "District %(district_id)s"
+
+#: /usr/src/app/config/config.xml:18
+msgid "dc_area_council long description"
+msgstr "DC Planning Council"
+
+#: /usr/src/app/config/config.xml:18
+msgid "dc_area_council members"
+msgstr "Districts"
+
+#: /usr/src/app/config/config.xml:20
+msgid "dc_community short label"
+msgstr "%(district_id)s"
+
+#: /usr/src/app/config/config.xml:20
+msgid "dc_community label"
+msgstr "Community %(district_id)s"
+
+#: /usr/src/app/config/config.xml:20
+msgid "dc_community long description"
+msgstr "DC Community Map"
+
+#: /usr/src/app/config/config.xml:20
+msgid "dc_community members"
+msgstr "Communities"
+
+#: /usr/src/app/config/config.xml:77
+msgid "govdem short label"
+msgstr "% Dem Gov. '09, Two-Party"
+
+#: /usr/src/app/config/config.xml:77
+msgid "govdem label"
+msgstr "Democratic Voters, Governor '09"
+
+#: /usr/src/app/config/config.xml:77
+msgid "govdem long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:80
+msgid "vapblk short label"
+msgstr "Black VAP"
+
+#: /usr/src/app/config/config.xml:80
+msgid "vapblk label"
+msgstr "Voting Age Population - African-American"
+
+#: /usr/src/app/config/config.xml:80
+msgid "vapblk long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:83
+msgid "vaphisp short label"
+msgstr "Hisp. VAP"
+
+#: /usr/src/app/config/config.xml:83
+msgid "vaphisp label"
+msgstr "Voting Age Population - Hispanic/Latino"
+
+#: /usr/src/app/config/config.xml:83
+msgid "vaphisp long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:85
+msgid "pophisp short label"
+msgstr "Hispanic"
+
+#: /usr/src/app/config/config.xml:85
+msgid "pophisp label"
+msgstr "Hispanic or Latino"
+
+#: /usr/src/app/config/config.xml:85
+msgid "pophisp long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:87
+msgid "popasn short label"
+msgstr "As Amer"
+
+#: /usr/src/app/config/config.xml:87
+msgid "popasn label"
+msgstr "Asian-American"
+
+#: /usr/src/app/config/config.xml:87
+msgid "popasn long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:89
+msgid "popnam short label"
+msgstr "Nat Amer"
+
+#: /usr/src/app/config/config.xml:89
+msgid "popnam label"
+msgstr "Native American"
+
+#: /usr/src/app/config/config.xml:89
+msgid "popnam long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:91
+msgid "poppild short label"
+msgstr "Pac Isldr"
+
+#: /usr/src/app/config/config.xml:91
+msgid "poppild label"
+msgstr "Pacific Islander"
+
+#: /usr/src/app/config/config.xml:91
+msgid "poppild long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:93
+msgid "vap short label"
+msgstr "Voters"
+
+#: /usr/src/app/config/config.xml:93
+msgid "vap label"
+msgstr "Voting Age Population"
+
+#: /usr/src/app/config/config.xml:93
+msgid "vap long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:96
+msgid "vapwnh short label"
+msgstr "Wht Votng Age"
+
+#: /usr/src/app/config/config.xml:96
+msgid "vapwnh label"
+msgstr "Voting Age Population - White"
+
+#: /usr/src/app/config/config.xml:96
+msgid "vapwnh long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:98
+msgid "popblk short label"
+msgstr "Black"
+
+#: /usr/src/app/config/config.xml:98
+msgid "popblk label"
+msgstr "African-American"
+
+#: /usr/src/app/config/config.xml:98
+msgid "popblk long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:100
+msgid "popwnh short label"
+msgstr "White"
+
+#: /usr/src/app/config/config.xml:100
+msgid "popwnh label"
+msgstr "Total White Non-Hispanic"
+
+#: /usr/src/app/config/config.xml:100
+msgid "popwnh long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:103
+msgid "vapasn short label"
+msgstr "As Am Votng Age"
+
+#: /usr/src/app/config/config.xml:103
+msgid "vapasn label"
+msgstr "Voting Age Population - Asian-American"
+
+#: /usr/src/app/config/config.xml:103
+msgid "vapasn long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:106
+msgid "vapnam short label"
+msgstr "Nat Amer Votng Age"
+
+#: /usr/src/app/config/config.xml:106
+msgid "vapnam label"
+msgstr "Voting Age Population - Native American"
+
+#: /usr/src/app/config/config.xml:106
+msgid "vapnam long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:109
+msgid "vappild short label"
+msgstr "Pac Isldr Votng Age"
+
+#: /usr/src/app/config/config.xml:109
+msgid "vappild label"
+msgstr "Voting Age Population - Pacific Islander"
+
+#: /usr/src/app/config/config.xml:109
+msgid "vappild long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:111
+msgid "presdem short label"
+msgstr "Democrat 08"
+
+#: /usr/src/app/config/config.xml:111
+msgid "presdem label"
+msgstr "Democratic Voters"
+
+#: /usr/src/app/config/config.xml:111
+msgid "presdem long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:113
+msgid "presrep short label"
+msgstr "Republican 08"
+
+#: /usr/src/app/config/config.xml:113
+msgid "presrep label"
+msgstr "Republican Voters"
+
+#: /usr/src/app/config/config.xml:113
+msgid "presrep long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:115
+msgid "poptot short label"
+msgstr "Total Pop."
+
+#: /usr/src/app/config/config.xml:115
+msgid "poptot label"
+msgstr "Total Population"
+
+#: /usr/src/app/config/config.xml:115
+msgid "poptot long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:117
+msgid "presoth short label"
+msgstr "Other 08"
+
+#: /usr/src/app/config/config.xml:117
+msgid "presoth label"
+msgstr "Other Voters"
+
+#: /usr/src/app/config/config.xml:117
+msgid "presoth long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:119
+msgid "govrep short label"
+msgstr "Republican 09"
+
+#: /usr/src/app/config/config.xml:119
+msgid "govrep label"
+msgstr "Republican Voters, Governor '09"
+
+#: /usr/src/app/config/config.xml:119
+msgid "govrep long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:121
+msgid "govoth short label"
+msgstr "Other Cand 09"
+
+#: /usr/src/app/config/config.xml:121
+msgid "govoth label"
+msgstr "Sum All Other Candidates, Governor '09"
+
+#: /usr/src/app/config/config.xml:121
+msgid "govoth long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:123
+msgid "govtot short label"
+msgstr "Governor"
+
+#: /usr/src/app/config/config.xml:123
+msgid "govtot label"
+msgstr "Total Voter, Governor '09"
+
+#: /usr/src/app/config/config.xml:123
+msgid "govtot long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:1006
+msgid "block short label"
+msgstr "block"
+
+#: /usr/src/app/config/config.xml:1006
+msgid "block label"
+msgstr "block"
+
+#: /usr/src/app/config/config.xml:1006
+msgid "block long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:1067
+msgid "vtd short label"
+msgstr "vtd"
+
+#: /usr/src/app/config/config.xml:1067
+msgid "vtd label"
+msgstr "vtd"
+
+#: /usr/src/app/config/config.xml:1067
+msgid "vtd long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:1121
+msgid "county short label"
+msgstr "county"
+
+#: /usr/src/app/config/config.xml:1121
+msgid "county label"
+msgstr "county"
+
+#: /usr/src/app/config/config.xml:1121
+msgid "county long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:37
+msgid "va_block short label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:37
+msgid "va_block label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:37
+msgid "va_block long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:38
+msgid "va_vtd short label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:38
+msgid "va_vtd label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:38
+msgid "va_vtd long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:39
+msgid "va_county short label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:39
+msgid "va_county label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:39
+msgid "va_county long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:62
+msgid "dc_block short label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:62
+msgid "dc_block label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:62
+msgid "dc_block long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:63
+msgid "dc_vtd short label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:63
+msgid "dc_vtd label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:63
+msgid "dc_vtd long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:654
+msgid "panel_competitive_all short label"
+msgstr "Competitiveness"
+
+#: /usr/src/app/config/config.xml:654
+msgid "panel_competitive_all label"
+msgstr "Competitiveness"
+
+#: /usr/src/app/config/config.xml:654
+msgid "panel_competitive_all long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:392
+msgid "plan_competitiveness short label"
+msgstr "Competitiveness"
+
+#: /usr/src/app/config/config.xml:392
+msgid "plan_competitiveness label"
+msgstr "Competitiveness"
+
+#: /usr/src/app/config/config.xml:392
+msgid "plan_competitiveness long description"
+msgstr ""
+"Each plan's overall political competitiveness is determined by averaging "
+"each district.s 'partisan differential'.  The partisan differential of each "
+"district is calculated by subtracting the Democratic 'partisan index' from "
+"the Republican 'partisan index'.<br/><br/>'Heavily' competitive districts "
+"are districts with partisan differentials of less than or equal to 5%. "
+"'Generally' competitive districts are districts with partisan differentials "
+"of greater than 5% but less than 10%."
+
+#: /usr/src/app/config/config.xml:662
+msgid "panel_rf_all short label"
+msgstr "Representational Fairness"
+
+#: /usr/src/app/config/config.xml:662
+msgid "panel_rf_all label"
+msgstr "Representational Fairness"
+
+#: /usr/src/app/config/config.xml:662
+msgid "panel_rf_all long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:453
+msgid "plan_repfairness short label"
+msgstr "Representational Fairness"
+
+#: /usr/src/app/config/config.xml:453
+msgid "plan_repfairness label"
+msgstr "Representational Fairness"
+
+#: /usr/src/app/config/config.xml:453
+msgid "plan_repfairness long description"
+msgstr ""
+"Representational fairness is increased when the percentage of districts a "
+"party would likely win (based upon the 'partisan index' used to determine "
+"Competitiveness) closely mirrors that party.s percentage of the statewide "
+"vote."
+
+#: /usr/src/app/config/config.xml:666
+msgid "panel_rf_mine short label"
+msgstr "Representational Fairness"
+
+#: /usr/src/app/config/config.xml:666
+msgid "panel_rf_mine label"
+msgstr "Representational Fairness"
+
+#: /usr/src/app/config/config.xml:666
+msgid "panel_rf_mine long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:824
+msgid "house_leader_all short label"
+msgstr "State House Leaderboard - All"
+
+#: /usr/src/app/config/config.xml:824
+msgid "house_leader_all label"
+msgstr "State House Leaderboard - All"
+
+#: /usr/src/app/config/config.xml:824
+msgid "house_leader_all long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:831
+msgid "house_leader_mine short label"
+msgstr "State House Leaderboard - Mine"
+
+#: /usr/src/app/config/config.xml:831
+msgid "house_leader_mine label"
+msgstr "State House Leaderboard - Mine"
+
+#: /usr/src/app/config/config.xml:831
+msgid "house_leader_mine long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:838
+msgid "senate_leader_all short label"
+msgstr "State Senate Leaderboard - All"
+
+#: /usr/src/app/config/config.xml:838
+msgid "senate_leader_all label"
+msgstr "State Senate Leaderboard - All"
+
+#: /usr/src/app/config/config.xml:838
+msgid "senate_leader_all long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:845
+msgid "senate_leader_mine short label"
+msgstr "State Senate Leaderboard - Mine"
+
+#: /usr/src/app/config/config.xml:845
+msgid "senate_leader_mine label"
+msgstr "State Senate Leaderboard - Mine"
+
+#: /usr/src/app/config/config.xml:845
+msgid "senate_leader_mine long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:407
+msgid "plan_majority_minority_blk_congress short label"
+msgstr "Black VAP Majority (>50%)"
+
+#: /usr/src/app/config/config.xml:407
+msgid "plan_majority_minority_blk_congress label"
+msgstr "Black VAP Majority (>50%)"
+
+#: /usr/src/app/config/config.xml:407
+msgid "plan_majority_minority_blk_congress long description"
+msgstr ""
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
+
+#: /usr/src/app/config/config.xml:434
+msgid "plan_majority_minority_hisp short label"
+msgstr "Hisp. VAP Majority (>50%)"
+
+#: /usr/src/app/config/config.xml:434
+msgid "plan_majority_minority_hisp label"
+msgstr "Hisp. VAP Majority (>50%)"
+
+#: /usr/src/app/config/config.xml:434
+msgid "plan_majority_minority_hisp long description"
+msgstr ""
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
+
+#: /usr/src/app/config/config.xml:467
+msgid "partisan_index short label"
+msgstr "Partisan Index"
+
+#: /usr/src/app/config/config.xml:467
+msgid "partisan_index label"
+msgstr "Partisan Index"
+
+#: /usr/src/app/config/config.xml:467
+msgid "partisan_index long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:136
+msgid "district_blkvap_percent short label"
+msgstr "Black VAP"
+
+#: /usr/src/app/config/config.xml:136
+msgid "district_blkvap_percent label"
+msgstr "Black VAP"
+
+#: /usr/src/app/config/config.xml:136
+msgid "district_blkvap_percent long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:152
+msgid "district_hispvap_percent short label"
+msgstr "His. VAP"
+
+#: /usr/src/app/config/config.xml:152
+msgid "district_hispvap_percent label"
+msgstr "His. VAP"
+
+#: /usr/src/app/config/config.xml:152
+msgid "district_hispvap_percent long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:863
+msgid "house_sidebar_basic short label"
+msgstr "Basic Information"
+
+#: /usr/src/app/config/config.xml:863
+msgid "house_sidebar_basic label"
+msgstr "Basic Information"
+
+#: /usr/src/app/config/config.xml:863
+msgid "house_sidebar_basic long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:680
+msgid "house_panel_summary short label"
+msgstr "Plan Summary"
+
+#: /usr/src/app/config/config.xml:680
+msgid "house_panel_summary label"
+msgstr "Plan Summary"
+
+#: /usr/src/app/config/config.xml:680
+msgid "house_panel_summary long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:350
+msgid "a_house_plan_equipopulation_summary short label"
+msgstr "Target Pop. (80,010)"
+
+#: /usr/src/app/config/config.xml:350
+msgid "a_house_plan_equipopulation_summary label"
+msgstr "Target Pop. (80,010)"
+
+#: /usr/src/app/config/config.xml:350
+msgid "a_house_plan_equipopulation_summary long description"
+msgstr ""
+"The population of each House of Delegates district must be 80,010 +/- 5%."
+
+#: /usr/src/app/config/config.xml:251
+msgid "b_plan_house_noncontiguous short label"
+msgstr "Contiguous"
+
+#: /usr/src/app/config/config.xml:251
+msgid "b_plan_house_noncontiguous label"
+msgstr "Contiguous"
+
+#: /usr/src/app/config/config.xml:251
+msgid "b_plan_house_noncontiguous long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:416
+msgid "plan_majority_minority_blk_house short label"
+msgstr "Black VAP Majority (>50%)"
+
+#: /usr/src/app/config/config.xml:416
+msgid "plan_majority_minority_blk_house label"
+msgstr "Black VAP Majority (>50%)"
+
+#: /usr/src/app/config/config.xml:416
+msgid "plan_majority_minority_blk_house long description"
+msgstr ""
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
+
+#: /usr/src/app/config/config.xml:714
+msgid "house_panel_info short label"
+msgstr "Basic Information"
+
+#: /usr/src/app/config/config.xml:714
+msgid "house_panel_info label"
+msgstr "Basic Information"
+
+#: /usr/src/app/config/config.xml:714
+msgid "house_panel_info long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:276
+msgid "a_house_population short label"
+msgstr "Tot Pop"
+
+#: /usr/src/app/config/config.xml:276
+msgid "a_house_population label"
+msgstr "Tot Pop"
+
+#: /usr/src/app/config/config.xml:276
+msgid "a_house_population long description"
+msgstr "Population interval calculator for house."
+
+#: /usr/src/app/config/config.xml:868
+msgid "house_sidebar_demo short label"
+msgstr "Demographics"
+
+#: /usr/src/app/config/config.xml:868
+msgid "house_sidebar_demo label"
+msgstr "Demographics"
+
+#: /usr/src/app/config/config.xml:868
+msgid "house_sidebar_demo long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:746
+msgid "house_panel_demo short label"
+msgstr "Demographics"
+
+#: /usr/src/app/config/config.xml:746
+msgid "house_panel_demo label"
+msgstr "Demographics"
+
+#: /usr/src/app/config/config.xml:746
+msgid "house_panel_demo long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:873
+msgid "senate_sidebar_basic short label"
+msgstr "Basic Information"
+
+#: /usr/src/app/config/config.xml:873
+msgid "senate_sidebar_basic label"
+msgstr "Basic Information"
+
+#: /usr/src/app/config/config.xml:873
+msgid "senate_sidebar_basic long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:688
+msgid "senate_panel_summary short label"
+msgstr "Plan Summary"
+
+#: /usr/src/app/config/config.xml:688
+msgid "senate_panel_summary label"
+msgstr "Plan Summary"
+
+#: /usr/src/app/config/config.xml:688
+msgid "senate_panel_summary long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:370
+msgid "a_senate_plan_equipopulation_summary short label"
+msgstr "Target Pop. (200,026)"
+
+#: /usr/src/app/config/config.xml:370
+msgid "a_senate_plan_equipopulation_summary label"
+msgstr "Target Pop. (200,026)"
+
+#: /usr/src/app/config/config.xml:370
+msgid "a_senate_plan_equipopulation_summary long description"
+msgstr "The population of each State Senate district must be 200,026 +/- 5%."
+
+#: /usr/src/app/config/config.xml:257
+msgid "b_plan_senate_noncontiguous short label"
+msgstr "Contiguous"
+
+#: /usr/src/app/config/config.xml:257
+msgid "b_plan_senate_noncontiguous label"
+msgstr "Contiguous"
+
+#: /usr/src/app/config/config.xml:257
+msgid "b_plan_senate_noncontiguous long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:425
+msgid "plan_majority_minority_blk_senate short label"
+msgstr "Black VAP Majority (>50%)"
+
+#: /usr/src/app/config/config.xml:425
+msgid "plan_majority_minority_blk_senate label"
+msgstr "Black VAP Majority (>50%)"
+
+#: /usr/src/app/config/config.xml:425
+msgid "plan_majority_minority_blk_senate long description"
+msgstr ""
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
+
+#: /usr/src/app/config/config.xml:722
+msgid "senate_panel_info short label"
+msgstr "Basic Information"
+
+#: /usr/src/app/config/config.xml:722
+msgid "senate_panel_info label"
+msgstr "Basic Information"
+
+#: /usr/src/app/config/config.xml:722
+msgid "senate_panel_info long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:287
+msgid "a_senate_population short label"
+msgstr "Tot Pop"
+
+#: /usr/src/app/config/config.xml:287
+msgid "a_senate_population label"
+msgstr "Tot Pop"
+
+#: /usr/src/app/config/config.xml:287
+msgid "a_senate_population long description"
+msgstr "Population interval calculator for senate."
+
+#: /usr/src/app/config/config.xml:878
+msgid "senate_sidebar_demo short label"
+msgstr "Demographics"
+
+#: /usr/src/app/config/config.xml:878
+msgid "senate_sidebar_demo label"
+msgstr "Demographics"
+
+#: /usr/src/app/config/config.xml:878
+msgid "senate_sidebar_demo long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:754
+msgid "senate_panel_demo short label"
+msgstr "Demographics"
+
+#: /usr/src/app/config/config.xml:754
+msgid "senate_panel_demo label"
+msgstr "Demographics"
+
+#: /usr/src/app/config/config.xml:754
+msgid "senate_panel_demo long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:487
+msgid "district_poptot short label"
+msgstr "Total Population"
+
+#: /usr/src/app/config/config.xml:487
+msgid "district_poptot label"
+msgstr "Total Population"
+
+#: /usr/src/app/config/config.xml:487
+msgid "district_poptot long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:477
+msgid "district_vap short label"
+msgstr "Voting Age Pop."
+
+#: /usr/src/app/config/config.xml:477
+msgid "district_vap label"
+msgstr "Voting Age Pop."
+
+#: /usr/src/app/config/config.xml:477
+msgid "district_vap long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:529
+msgid "report_score_vap short label"
+msgstr "Voting Age Population"
+
+#: /usr/src/app/config/config.xml:529
+msgid "report_score_vap label"
+msgstr "Voting Age Population"
+
+#: /usr/src/app/config/config.xml:529
+msgid "report_score_vap long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:538
+msgid "report_score_vapblk short label"
+msgstr "VAP African-American"
+
+#: /usr/src/app/config/config.xml:538
+msgid "report_score_vapblk label"
+msgstr "VAP African-American"
+
+#: /usr/src/app/config/config.xml:538
+msgid "report_score_vapblk long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:547
+msgid "report_score_vaphisp short label"
+msgstr "VAP Hispanic/Latino"
+
+#: /usr/src/app/config/config.xml:547
+msgid "report_score_vaphisp label"
+msgstr "VAP Hispanic/Latino"
+
+#: /usr/src/app/config/config.xml:547
+msgid "report_score_vaphisp long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:781
+msgid "report_panel_majmin short label"
+msgstr "Majority Minority Districts"
+
+#: /usr/src/app/config/config.xml:781
+msgid "report_panel_majmin label"
+msgstr "Majority Minority Districts"
+
+#: /usr/src/app/config/config.xml:781
+msgid "report_panel_majmin long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:557
+msgid "report_score_majmin_blk short label"
+msgstr "VAP African-American"
+
+#: /usr/src/app/config/config.xml:557
+msgid "report_score_majmin_blk label"
+msgstr "VAP African-American"
+
+#: /usr/src/app/config/config.xml:557
+msgid "report_score_majmin_blk long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:567
+msgid "report_score_majmin_hisp short label"
+msgstr "VAP Hispanic/Latino"
+
+#: /usr/src/app/config/config.xml:567
+msgid "report_score_majmin_hisp label"
+msgstr "VAP Hispanic/Latino"
+
+#: /usr/src/app/config/config.xml:567
+msgid "report_score_majmin_hisp long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:796
+msgid "report_panel_party short label"
+msgstr "Party-Controlled Districts"
+
+#: /usr/src/app/config/config.xml:796
+msgid "report_panel_party label"
+msgstr "Party-Controlled Districts"
+
+#: /usr/src/app/config/config.xml:796
+msgid "report_panel_party long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:606
+msgid "report_score_party_dem short label"
+msgstr "Democratic"
+
+#: /usr/src/app/config/config.xml:606
+msgid "report_score_party_dem label"
+msgstr "Democratic"
+
+#: /usr/src/app/config/config.xml:606
+msgid "report_score_party_dem long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:616
+msgid "report_score_party_rep short label"
+msgstr "Republican"
+
+#: /usr/src/app/config/config.xml:616
+msgid "report_score_party_rep label"
+msgstr "Republican"
+
+#: /usr/src/app/config/config.xml:616
+msgid "report_score_party_rep long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:904
+msgid "senate_reports short label"
+msgstr "State Senate Reports"
+
+#: /usr/src/app/config/config.xml:904
+msgid "senate_reports label"
+msgstr "State Senate Reports"
+
+#: /usr/src/app/config/config.xml:904
+msgid "senate_reports long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:913
+msgid "house_reports short label"
+msgstr "State House Reports"
+
+#: /usr/src/app/config/config.xml:913
+msgid "house_reports label"
+msgstr "State House Reports"
+
+#: /usr/src/app/config/config.xml:913
+msgid "house_reports long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:146
+msgid "district_blkvap_thresh short label"
+msgstr "Black VAP Threshold"
+
+#: /usr/src/app/config/config.xml:146
+msgid "district_blkvap_thresh label"
+msgstr "Black VAP Threshold"
+
+#: /usr/src/app/config/config.xml:146
+msgid "district_blkvap_thresh long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:162
+msgid "district_hispvap_thresh short label"
+msgstr "His. VAP Threshold"
+
+#: /usr/src/app/config/config.xml:162
+msgid "district_hispvap_thresh label"
+msgstr "His. VAP Threshold"
+
+#: /usr/src/app/config/config.xml:162
+msgid "district_hispvap_thresh long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:172
+msgid "district_mintot short label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:172
+msgid "district_mintot label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:172
+msgid "district_mintot long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:177
+msgid "district_majmin short label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:177
+msgid "district_majmin label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:177
+msgid "district_majmin long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio short label"
+msgstr "Convex Hull Ratio"
+
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio label"
+msgstr "Convex Hull Ratio"
+
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:213
+msgid "plan_count_majmin short label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:213
+msgid "plan_count_majmin label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:213
+msgid "plan_count_majmin long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:218
+msgid "plan_blkvap_thresh short label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:218
+msgid "plan_blkvap_thresh label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:218
+msgid "plan_blkvap_thresh long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:223
+msgid "plan_hispvap_thresh short label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:223
+msgid "plan_hispvap_thresh label"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:223
+msgid "plan_hispvap_thresh long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:232
+msgid "plan_major_minor short label"
+msgstr "Majority-Minority"
+
+#: /usr/src/app/config/config.xml:232
+msgid "plan_major_minor label"
+msgstr "Majority-Minority"
+
+#: /usr/src/app/config/config.xml:232
+msgid "plan_major_minor long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:306
+msgid "a_house_plan_count_districts short label"
+msgstr "Count Districts"
+
+#: /usr/src/app/config/config.xml:306
+msgid "a_house_plan_count_districts label"
+msgstr "Count Districts"
+
+#: /usr/src/app/config/config.xml:306
+msgid "a_house_plan_count_districts long description"
+msgstr ""
+"The number of districts in a House of Delegates redistricting plan must be "
+"100."
+
+#: /usr/src/app/config/config.xml:313
+msgid "a_senate_plan_count_districts short label"
+msgstr "Count Districts"
+
+#: /usr/src/app/config/config.xml:313
+msgid "a_senate_plan_count_districts label"
+msgstr "Count Districts"
+
+#: /usr/src/app/config/config.xml:313
+msgid "a_senate_plan_count_districts long description"
+msgstr ""
+"The number of districts in a State Senate redistricting plan must be 100."
+
+#: /usr/src/app/config/config.xml:340
+msgid "a_house_plan_equipopulation_validation short label"
+msgstr "Target Pop. (80,010)"
+
+#: /usr/src/app/config/config.xml:340
+msgid "a_house_plan_equipopulation_validation label"
+msgstr "Target Pop. (80,010)"
+
+#: /usr/src/app/config/config.xml:340
+msgid "a_house_plan_equipopulation_validation long description"
+msgstr ""
+"The population of each House of Delegates district must be 80,010 +/- 5%."
+
+#: /usr/src/app/config/config.xml:360
+msgid "a_senate_plan_equipopulation_validation short label"
+msgstr "Target Pop. (200,026)"
+
+#: /usr/src/app/config/config.xml:360
+msgid "a_senate_plan_equipopulation_validation label"
+msgstr "Target Pop. (200,026)"
+
+#: /usr/src/app/config/config.xml:360
+msgid "a_senate_plan_equipopulation_validation long description"
+msgstr "The population of each State Senate district must be 200,026 +/- 5%."
+
+#: /usr/src/app/config/config.xml:443
+msgid "plan_majority_minority short label"
+msgstr "Majority Minority District"
+
+#: /usr/src/app/config/config.xml:443
+msgid "plan_majority_minority label"
+msgstr "Majority Minority District"
+
+#: /usr/src/app/config/config.xml:443
+msgid "plan_majority_minority long description"
+msgstr ""
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
+
+#: /usr/src/app/config/config.xml:933
+msgid "congress-major-minor short label"
+msgstr "MajorityMinority - Congress"
+
+#: /usr/src/app/config/config.xml:933
+msgid "congress-major-minor label"
+msgstr "MajorityMinority - Congress"
+
+#: /usr/src/app/config/config.xml:933
+msgid "congress-major-minor long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:945
+msgid "house-equipop short label"
+msgstr "Equipopulation - House"
+
+#: /usr/src/app/config/config.xml:945
+msgid "house-equipop label"
+msgstr "Equipopulation - House"
+
+#: /usr/src/app/config/config.xml:945
+msgid "house-equipop long description"
+msgstr ""
+"<p>Your plan does not meet the competition criteria for "
+"Equipopulation:</p><p>The population of each House of Delegates district "
+"must be 80,010 +/- 5%.</p>"
+
+#: /usr/src/app/config/config.xml:949
+msgid "house-contiguous short label"
+msgstr "AllContiguous - House"
+
+#: /usr/src/app/config/config.xml:949
+msgid "house-contiguous label"
+msgstr "AllContiguous - House"
+
+#: /usr/src/app/config/config.xml:949
+msgid "house-contiguous long description"
+msgstr ""
+"<p>Your plan does not meet the competition criteria for "
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
+
+#: /usr/src/app/config/config.xml:952
+msgid "house-major-minor short label"
+msgstr "MajorityMinority - House"
+
+#: /usr/src/app/config/config.xml:952
+msgid "house-major-minor label"
+msgstr "MajorityMinority - House"
+
+#: /usr/src/app/config/config.xml:952
+msgid "house-major-minor long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:955
+msgid "house-district-count short label"
+msgstr "CountDistricts - House"
+
+#: /usr/src/app/config/config.xml:955
+msgid "house-district-count label"
+msgstr "CountDistricts - House"
+
+#: /usr/src/app/config/config.xml:955
+msgid "house-district-count long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:958
+msgid "house-assigned short label"
+msgstr "AllBlocksAssigned - House"
+
+#: /usr/src/app/config/config.xml:958
+msgid "house-assigned label"
+msgstr "AllBlocksAssigned - House"
+
+#: /usr/src/app/config/config.xml:958
+msgid "house-assigned long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:964
+msgid "senate-equipop short label"
+msgstr "Equipopulation - Senate"
+
+#: /usr/src/app/config/config.xml:964
+msgid "senate-equipop label"
+msgstr "Equipopulation - Senate"
+
+#: /usr/src/app/config/config.xml:964
+msgid "senate-equipop long description"
+msgstr ""
+"<p>Your plan does not meet the competition criteria for "
+"Equipopulation:</p><p>The population of each House of Delegates district "
+"must be 200,026 +/- 5%.</p>"
+
+#: /usr/src/app/config/config.xml:968
+msgid "senate-contiguous short label"
+msgstr "AllContiguous - Senate"
+
+#: /usr/src/app/config/config.xml:968
+msgid "senate-contiguous label"
+msgstr "AllContiguous - Senate"
+
+#: /usr/src/app/config/config.xml:968
+msgid "senate-contiguous long description"
+msgstr ""
+"<p>Your plan does not meet the competition criteria for "
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
+
+#: /usr/src/app/config/config.xml:971
+msgid "senate-major-minor short label"
+msgstr "MajorityMinority - Senate"
+
+#: /usr/src/app/config/config.xml:971
+msgid "senate-major-minor label"
+msgstr "MajorityMinority - Senate"
+
+#: /usr/src/app/config/config.xml:971
+msgid "senate-major-minor long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:974
+msgid "senate-district-count short label"
+msgstr "CountDistricts - Senate"
+
+#: /usr/src/app/config/config.xml:974
+msgid "senate-district-count label"
+msgstr "CountDistricts - Senate"
+
+#: /usr/src/app/config/config.xml:974
+msgid "senate-district-count long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:977
+msgid "senate-assigned short label"
+msgstr "AllBlocksAssigned - Senate"
+
+#: /usr/src/app/config/config.xml:977
+msgid "senate-assigned label"
+msgstr "AllBlocksAssigned - Senate"
+
+#: /usr/src/app/config/config.xml:977
+msgid "senate-assigned long description"
+msgstr ""

--- a/django/publicmapping/locale/es/LC_MESSAGES/xmlconfig.po
+++ b/django/publicmapping/locale/es/LC_MESSAGES/xmlconfig.po
@@ -7,10 +7,10 @@ msgstr ""
 "PO-Revision-Date: 2012-01-14 01:47+0000\n"
 "Last-Translator: admin <dzwarg+admin@azavea.com>\n"
 "Language-Team: admin <dzwarg+admin@azavea.com>\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
 
 msgid "default short label"
 msgstr "Por Defecto"
@@ -27,15 +27,15 @@ msgstr "%(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:10
 msgid "congress label"
-msgstr "Distrito %(district_id)s"
+msgstr "District %(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:10
 msgid "congress long description"
-msgstr "Del Congreso"
+msgstr "Congressional"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:10
 msgid "congress members"
-msgstr "Distritos"
+msgstr "Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:12
 msgid "house short label"
@@ -43,15 +43,15 @@ msgstr "%(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:12
 msgid "house label"
-msgstr "Distrito %(district_id)s"
+msgstr "District %(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:12
 msgid "house long description"
-msgstr "Casa de los delegados de Estado"
+msgstr "State House"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:12
 msgid "house members"
-msgstr "Distritos"
+msgstr "Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:14
 msgid "senate short label"
@@ -59,15 +59,15 @@ msgstr "%(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:14
 msgid "senate label"
-msgstr "Distrito %(district_id)s"
+msgstr "District %(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:14
 msgid "senate long description"
-msgstr "Senado de Estado"
+msgstr "State Senate"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:14
 msgid "senate members"
-msgstr "Distritos"
+msgstr "Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:16
 msgid "community short label"
@@ -75,15 +75,15 @@ msgstr "%(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:16
 msgid "community label"
-msgstr "Comunidad %(district_id)s"
+msgstr "Community %(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:16
 msgid "community long description"
-msgstr "Mapa de Comunidad"
+msgstr "Community Map"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:16
 msgid "community members"
-msgstr "Comunidades"
+msgstr "Communities"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:27
 msgid "va short label"
@@ -95,7 +95,7 @@ msgstr "Virginia"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:27
 msgid "va long description"
-msgstr "El Estado de Virginia"
+msgstr "The Commonwealth of Virginia"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:45
 msgid "dc short label"
@@ -103,11 +103,11 @@ msgstr "dc"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:45
 msgid "dc label"
-msgstr "DC Metropolitana"
+msgstr "DC Metro"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:45
 msgid "dc long description"
-msgstr "El Área Metropolitana del Distrito de Columbia"
+msgstr "The District of Columbia Metropolitan Area"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:18
 msgid "dc_area_council short label"
@@ -115,15 +115,15 @@ msgstr "%(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:18
 msgid "dc_area_council label"
-msgstr "Distrito %(district_id)s"
+msgstr "District %(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:18
 msgid "dc_area_council long description"
-msgstr "Concejo de Planificación de DC"
+msgstr "DC Planning Council"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:18
 msgid "dc_area_council members"
-msgstr "Distritos"
+msgstr "Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:20
 msgid "dc_community short label"
@@ -131,87 +131,87 @@ msgstr "%(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:20
 msgid "dc_community label"
-msgstr "Comunidad %(district_id)s"
+msgstr "Community %(district_id)s"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:20
 msgid "dc_community long description"
-msgstr "Mapa de Comunidad de DC"
+msgstr "DC Community Map"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:20
 msgid "dc_community members"
-msgstr "Comunidades"
+msgstr "Communities"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:63
 msgid "dc_vtd short label"
-msgstr "vtd"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:63
 msgid "dc_vtd label"
-msgstr "VTD"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:63
 msgid "dc_vtd long description"
-msgstr "VTD"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:62
 msgid "dc_block short label"
-msgstr "cuadra"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:62
 msgid "dc_block label"
-msgstr "Cuadra"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:62
 msgid "dc_block long description"
-msgstr "Cuadra"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1142
 msgid "county short label"
-msgstr "condado"
+msgstr "county"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1142
 msgid "county label"
-msgstr "Condado"
+msgstr "county"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1142
 msgid "county long description"
-msgstr "Condado"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:37
 msgid "va_block short label"
-msgstr "cuadra"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:37
 msgid "va_block label"
-msgstr "Cuadra"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:37
 msgid "va_block long description"
-msgstr "Cuadra"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:38
 msgid "va_vtd short label"
-msgstr "vtd"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:38
 msgid "va_vtd label"
-msgstr "VTD"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:38
 msgid "va_vtd long description"
-msgstr "VTD"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:39
 msgid "va_county short label"
-msgstr "condado"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:39
 msgid "va_county label"
-msgstr "condado"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:39
 msgid "va_county long description"
-msgstr "Condado"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1088
 msgid "vtd short label"
@@ -219,31 +219,31 @@ msgstr "vtd"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1088
 msgid "vtd label"
-msgstr "VTD"
+msgstr "vtd"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1088
 msgid "vtd long description"
-msgstr "VTD"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1027
 msgid "block short label"
-msgstr "cyadra"
+msgstr "block"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1027
 msgid "block label"
-msgstr "Cuadra"
+msgstr "block"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1027
 msgid "block long description"
-msgstr "Cuadra"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:853
 msgid "congress_leader_all short label"
-msgstr "Tabla de Posiciones del Congreso - Todos"
+msgstr "Congressional Leaderboard - All"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:853
 msgid "congress_leader_all label"
-msgstr "Tabla de Posiciones del Congreso - Todos"
+msgstr "Congressional Leaderboard - All"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:853
 msgid "congress_leader_all long description"
@@ -251,11 +251,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:860
 msgid "congress_leader_mine short label"
-msgstr "Tabla de Posiciones del Congreso - Mío"
+msgstr "Congressional Leaderboard - Mine"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:860
 msgid "congress_leader_mine label"
-msgstr "Tabla de Posiciones del Congreso - Mío"
+msgstr "Congressional Leaderboard - Mine"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:860
 msgid "congress_leader_mine long description"
@@ -263,11 +263,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:867
 msgid "house_leader_all short label"
-msgstr "Tabla de Posiciones de la Casa de Delegados de Estado - Todos"
+msgstr "State House Leaderboard - All"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:867
 msgid "house_leader_all label"
-msgstr "Tabla de Posiciones de la Casa de Delegados de Estado - Todos"
+msgstr "State House Leaderboard - All"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:867
 msgid "house_leader_all long description"
@@ -275,11 +275,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:874
 msgid "house_leader_mine short label"
-msgstr "Tabla de Posiciones de la Casa de Delegados de Estado - Mío"
+msgstr "State House Leaderboard - Mine"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:874
 msgid "house_leader_mine label"
-msgstr "Tabla de Posiciones de la Casa de Delegados de Estado - Mío"
+msgstr "State House Leaderboard - Mine"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:874
 msgid "house_leader_mine long description"
@@ -287,11 +287,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:881
 msgid "senate_leader_all short label"
-msgstr "Tabla de Posiciones del Senado de Estado - Todos"
+msgstr "State Senate Leaderboard - All"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:881
 msgid "senate_leader_all label"
-msgstr "Tabla de Posiciones del Senado de Estado - Todos"
+msgstr "State Senate Leaderboard - All"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:881
 msgid "senate_leader_all long description"
@@ -299,11 +299,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:888
 msgid "senate_leader_mine short label"
-msgstr "Tabla de Posiciones del Senado de Estado - Mío"
+msgstr "State Senate Leaderboard - Mine"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:888
 msgid "senate_leader_mine label"
-msgstr "Tabla de Posiciones del Senado de Estado - Mío"
+msgstr "State Senate Leaderboard - Mine"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:888
 msgid "senate_leader_mine long description"
@@ -311,11 +311,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:896
 msgid "congress_sidebar_basic short label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:896
 msgid "congress_sidebar_basic label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:896
 msgid "congress_sidebar_basic long description"
@@ -323,11 +323,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:901
 msgid "congress_sidebar_demo short label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:901
 msgid "congress_sidebar_demo label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:901
 msgid "congress_sidebar_demo long description"
@@ -335,11 +335,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:906
 msgid "house_sidebar_basic short label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:906
 msgid "house_sidebar_basic label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:906
 msgid "house_sidebar_basic long description"
@@ -347,11 +347,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:911
 msgid "house_sidebar_demo short label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:911
 msgid "house_sidebar_demo label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:911
 msgid "house_sidebar_demo long description"
@@ -359,11 +359,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:916
 msgid "senate_sidebar_basic short label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:916
 msgid "senate_sidebar_basic label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:916
 msgid "senate_sidebar_basic long description"
@@ -371,11 +371,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:921
 msgid "senate_sidebar_demo short label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:921
 msgid "senate_sidebar_demo label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:921
 msgid "senate_sidebar_demo long description"
@@ -437,11 +437,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:938
 msgid "congress_reports short label"
-msgstr "Informes Sobre el Congreso"
+msgstr "Congressional Reports"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:938
 msgid "congress_reports label"
-msgstr "Informes Sobre el Congreso"
+msgstr "Congressional Reports"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:938
 msgid "congress_reports long description"
@@ -449,11 +449,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:947
 msgid "senate_reports short label"
-msgstr "Informes Sobre el Senado de Estado"
+msgstr "State Senate Reports"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:947
 msgid "senate_reports label"
-msgstr "Informes Sobre el Senado de Estado"
+msgstr "State Senate Reports"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:947
 msgid "senate_reports long description"
@@ -461,11 +461,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:956
 msgid "house_reports short label"
-msgstr "Informes Sobre la Casa de Delegados de Estado"
+msgstr "State House Reports"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:956
 msgid "house_reports label"
-msgstr "Informes Sobre la Casa de Delegados de Estado"
+msgstr "State House Reports"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:956
 msgid "house_reports long description"
@@ -482,53 +482,54 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:311
 msgid "a_congressional_population short label"
-msgstr "Pob. Tot"
+msgstr "Tot Pop"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:311
 msgid "a_congressional_population label"
-msgstr "Pob. Tot"
+msgstr "Tot Pop"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:311
 msgid "a_congressional_population long description"
-msgstr "Calculadora de Intervalo de Población para el Congreso."
+msgstr "Population interval calculator for congressional."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:342
 msgid "a_congress_plan_count_districts short label"
-msgstr "Contar Distritos"
+msgstr "Count Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:342
 msgid "a_congress_plan_count_districts label"
-msgstr "Contar Distritos"
+msgstr "Count Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:342
 msgid "a_congress_plan_count_districts long description"
 msgstr ""
-"El Número de Distritos en un Plan de Redistribución de Distritos Debe "
-"Ser 11"
+"The number of districts in a Congressional redistricting plan must be 11."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:373
 msgid "a_congress_plan_equipopulation_summary short label"
-msgstr "Pob. Objetivo (727,366)"
+msgstr "Target Pop. (727,366)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:373
 msgid "a_congress_plan_equipopulation_summary label"
-msgstr "Pob. Objetivo (727,366)"
+msgstr "Target Pop. (727,366)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:373
 msgid "a_congress_plan_equipopulation_summary long description"
-msgstr "La Población de Cada Distrito del Congreso Debe Ser 727,366 +/- 0.5%."
+msgstr ""
+"The population of each Congressional district must be 727,366 +/- 0.5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:363
 msgid "a_congress_plan_equipopulation_validation short label"
-msgstr "Pob. Objetivo (727,366)"
+msgstr "Target Pop. (727,366)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:363
 msgid "a_congress_plan_equipopulation_validation label"
-msgstr "Pob. Objetivo (727,366)"
+msgstr "Target Pop. (727,366)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:363
 msgid "a_congress_plan_equipopulation_validation long description"
-msgstr "La Población de Cada Distrito del Congreso Debe Ser 727,366 +/- 0.5%."
+msgstr ""
+"The population of each Congressional district must be 727,366 +/- 0.5%."
 
 msgid "a_dc_area_council_plan_equipopulation_summary short label"
 msgstr "Pob. Objetivo (292,843)"
@@ -538,8 +539,7 @@ msgstr "Pob. Objetivo (292,843)"
 
 msgid "a_dc_area_council_plan_equipopulation_summary long description"
 msgstr ""
-"La Población de Cada Distrito del Senado de Estado Debe Ser 292,843 "
-"+/- 5%."
+"La Población de Cada Distrito del Senado de Estado Debe Ser 292,843 +/- 5%."
 
 msgid "a_dc_area_council_plan_equipopulation_validation short label"
 msgstr "Pob. Objetivo (292,843)"
@@ -549,8 +549,7 @@ msgstr "Pob. Objetivo (292,843)"
 
 msgid "a_dc_area_council_plan_equipopulation_validation long description"
 msgstr ""
-"La Población de Cada Distrito del Senado de Estado Debe Ser 292,843 "
-"+/- 5%."
+"La Población de Cada Distrito del Senado de Estado Debe Ser 292,843 +/- 5%."
 
 msgid "a_dc_area_council_population short label"
 msgstr "Pob. Tot"
@@ -563,119 +562,112 @@ msgstr "Calculadora de Intervalo de Población para el Senado."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:349
 msgid "a_house_plan_count_districts short label"
-msgstr "Contar Distritos"
+msgstr "Count Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:349
 msgid "a_house_plan_count_districts label"
-msgstr "Contar Distritos"
+msgstr "Count Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:349
 msgid "a_house_plan_count_districts long description"
 msgstr ""
-"El Número de Distritos en un Plan de Redistribución de Distritos de la"
-" Casa de Delegados Debe Ser 100."
+"The number of districts in a House of Delegates redistricting plan must be "
+"100."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:393
 msgid "a_house_plan_equipopulation_summary short label"
-msgstr "Pob. Objetivo (80,010)"
+msgstr "Target Pop. (80,010)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:393
 msgid "a_house_plan_equipopulation_summary label"
-msgstr "Pob. Objetivo (80,010)"
+msgstr "Target Pop. (80,010)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:393
 msgid "a_house_plan_equipopulation_summary long description"
 msgstr ""
-"La Población de Cada Distrito de la Casa de Delegados Debe Ser 80,010 "
-"+/- 5%."
+"The population of each House of Delegates district must be 80,010 +/- 5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:383
 msgid "a_house_plan_equipopulation_validation short label"
-msgstr "Pob. Objetivo (80,010)"
+msgstr "Target Pop. (80,010)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:383
 msgid "a_house_plan_equipopulation_validation label"
-msgstr "Pob. Objetivo (80,010)"
+msgstr "Target Pop. (80,010)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:383
 msgid "a_house_plan_equipopulation_validation long description"
 msgstr ""
-"La Población de Cada Distrito de la Casa de Delegados Debe Ser 80,010 "
-"+/- 5%."
+"The population of each House of Delegates district must be 80,010 +/- 5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:321
 msgid "a_house_population short label"
-msgstr "Pob. Tot"
+msgstr "Tot Pop"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:321
 msgid "a_house_population label"
-msgstr "Pob. Tot"
+msgstr "Tot Pop"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:321
 msgid "a_house_population long description"
-msgstr "Calculadora de Intervalo de Población para la Casa de Delegados"
+msgstr "Population interval calculator for house."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:356
 msgid "a_senate_plan_count_districts short label"
-msgstr "Contar Distritos"
+msgstr "Count Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:356
 msgid "a_senate_plan_count_districts label"
-msgstr "Contar Distritos"
+msgstr "Count Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:356
 msgid "a_senate_plan_count_districts long description"
 msgstr ""
-"El Número de Distritos en un Plan de Redistribución de Distritos del "
-"Senado de Estado Debe Ser 100."
+"The number of districts in a State Senate redistricting plan must be 100."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:413
 msgid "a_senate_plan_equipopulation_summary short label"
-msgstr "Pob. Objetivo (200,026)"
+msgstr "Target Pop. (200,026)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:413
 msgid "a_senate_plan_equipopulation_summary label"
-msgstr "Pob. Objetivo (200,026)"
+msgstr "Target Pop. (200,026)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:413
 msgid "a_senate_plan_equipopulation_summary long description"
-msgstr ""
-"La Población de Cada Distrito del Senado de Estado Debe Ser 200,026 "
-"+/- 5%."
+msgstr "The population of each State Senate district must be 200,026 +/- 5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:403
 msgid "a_senate_plan_equipopulation_validation short label"
-msgstr "Pob. Objetivo (200,026)"
+msgstr "Target Pop. (200,026)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:403
 msgid "a_senate_plan_equipopulation_validation label"
-msgstr "Pob. Objetivo (200,026)"
+msgstr "Target Pop. (200,026)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:403
 msgid "a_senate_plan_equipopulation_validation long description"
-msgstr ""
-"La Población de Cada Distrito del Senado de Estado Debe Ser 200,026 "
-"+/- 5%."
+msgstr "The population of each State Senate district must be 200,026 +/- 5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:331
 msgid "a_senate_population short label"
-msgstr "Pob. Tot"
+msgstr "Tot Pop"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:331
 msgid "a_senate_population label"
-msgstr "Pob. Tot"
+msgstr "Tot Pop"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:331
 msgid "a_senate_population long description"
-msgstr "Calculadora de Intervalo de Población para el Senado."
+msgstr "Population interval calculator for senate."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:291
 msgid "b_plan_congress_noncontiguous short label"
-msgstr "Contiguo"
+msgstr "Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:291
 msgid "b_plan_congress_noncontiguous label"
-msgstr "Contiguo"
+msgstr "Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:291
 msgid "b_plan_congress_noncontiguous long description"
@@ -692,11 +684,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:297
 msgid "b_plan_house_noncontiguous short label"
-msgstr "Contiguo"
+msgstr "Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:297
 msgid "b_plan_house_noncontiguous label"
-msgstr "Contiguo"
+msgstr "Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:297
 msgid "b_plan_house_noncontiguous long description"
@@ -704,11 +696,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:303
 msgid "b_plan_senate_noncontiguous short label"
-msgstr "Contiguo"
+msgstr "Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:303
 msgid "b_plan_senate_noncontiguous label"
-msgstr "Contiguo"
+msgstr "Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:303
 msgid "b_plan_senate_noncontiguous long description"
@@ -716,11 +708,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:136
 msgid "district_blkvap_percent short label"
-msgstr "Negro VAP"
+msgstr "Black VAP"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:136
 msgid "district_blkvap_percent label"
-msgstr "Negro VAP"
+msgstr "Black VAP"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:136
 msgid "district_blkvap_percent long description"
@@ -728,11 +720,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:146
 msgid "district_blkvap_thresh short label"
-msgstr "Límite Mínimo de Negro VAP"
+msgstr "Black VAP Threshold"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:146
 msgid "district_blkvap_thresh label"
-msgstr "Límite Mínimo de Negro VAP"
+msgstr "Black VAP Threshold"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:146
 msgid "district_blkvap_thresh long description"
@@ -740,11 +732,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:537
 msgid "district_comments short label"
-msgstr "Comentarios"
+msgstr "Comments"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:537
 msgid "district_comments label"
-msgstr "Comentarios"
+msgstr "Comments"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:537
 msgid "district_comments long description"
@@ -752,11 +744,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:230
 msgid "district_contiguous short label"
-msgstr "Contiguo"
+msgstr "Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:230
 msgid "district_contiguous label"
-msgstr "Contiguo"
+msgstr "Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:230
 msgid "district_contiguous long description"
@@ -776,11 +768,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:162
 msgid "district_hispvap_thresh short label"
-msgstr "Límite Mínimo de His. VAP"
+msgstr "His. VAP Threshold"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:162
 msgid "district_hispvap_thresh label"
-msgstr "Límite Mínimo de His. VAP"
+msgstr "His. VAP Threshold"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:162
 msgid "district_hispvap_thresh long description"
@@ -812,11 +804,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:530
 msgid "district_poptot short label"
-msgstr "Población Total"
+msgstr "Total Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:530
 msgid "district_poptot label"
-msgstr "Población Total"
+msgstr "Total Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:530
 msgid "district_poptot long description"
@@ -872,11 +864,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:221
 msgid "district_schwartzberg short label"
-msgstr "Compacidad"
+msgstr "Compactness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:221
 msgid "district_schwartzberg label"
-msgstr "Compacidad"
+msgstr "Compactness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:221
 msgid "district_schwartzberg long description"
@@ -884,11 +876,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:520
 msgid "district_vap short label"
-msgstr "Pob. en Edad de Votar"
+msgstr "Voting Age Pop."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:520
 msgid "district_vap label"
-msgstr "Pob. en Edad de Votar"
+msgstr "Voting Age Pop."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:520
 msgid "district_vap long description"
@@ -896,11 +888,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:510
 msgid "partisan_index short label"
-msgstr "Índice Partidista"
+msgstr "Partisan Index"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:510
 msgid "partisan_index label"
-msgstr "Índice Partidista"
+msgstr "Partisan Index"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:510
 msgid "partisan_index long description"
@@ -908,34 +900,33 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:423
 msgid "plan_all_blocks_assigned short label"
-msgstr "Todas las Cuadras Asignadas"
+msgstr "All Blocks Assigned"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:423
 msgid "plan_all_blocks_assigned label"
-msgstr "Todas las Cuadras Asignadas"
+msgstr "All Blocks Assigned"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:423
 msgid "plan_all_blocks_assigned long description"
-msgstr "Todas las cuadras en el plan deben ser asignadas."
+msgstr "All blocks in the plan must be assigned."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:429
 msgid "plan_all_contiguous short label"
-msgstr "Todos Contiguos"
+msgstr "All Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:429
 msgid "plan_all_contiguous label"
-msgstr "Todos Contiguos"
+msgstr "All Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:429
 msgid "plan_all_contiguous long description"
 msgstr ""
-"Contigüidad significa que todas las partes de un distrito deben ser "
-"accesibles desde cualquier otra parte sin cruzar las fronteras del "
-"distrito. Todos los distritos dentro de un plan deben ser contiguos. "
-"La contigüidad del agua es permitida debido a la extensa región "
-"costera que posee Virginia. Contigüidad por punto o contigüidad por"
-" toque de punto donde dos secciones de un distrito están conectadas "
-"en un solo punto no está permitido."
+"Contiguity means that every part of a district must be reachable from every "
+"other part without crossing the district's borders. All districts within a "
+"plan must be contiguous. Water contiguity is permitted given Virginia's "
+"extensive coastal region. 'Point contiguity' or 'touch-point contiguity' "
+"where two sections of a district are connected at a single point is not "
+"permitted."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:243
 msgid "plan_all_equipop short label"
@@ -963,30 +954,30 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:435
 msgid "plan_competitiveness short label"
-msgstr "Competitividad"
+msgstr "Competitiveness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:435
 msgid "plan_competitiveness label"
-msgstr "Competitividad"
+msgstr "Competitiveness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:435
 msgid "plan_competitiveness long description"
 msgstr ""
-"La competitividad política de cada plan está determinada por un "
-"promedio de la diferencia partidista de cada distrito. Se calcula "
-"restando el índice partidista Demócrata del índice partidista "
-"Republicano. Los distritos muy competitivos son los distritos con "
-"diferencias partidistas de menor o igual a 5%. Distritos generalmente "
-"competitivos son los distritos con diferencias partidistas entre 5% y "
-"10%."
+"Each plan's overall political competitiveness is determined by averaging "
+"each district.s 'partisan differential'.  The partisan differential of each "
+"district is calculated by subtracting the Democratic 'partisan index' from "
+"the Republican 'partisan index'.<br/><br/>'Heavily' competitive districts "
+"are districts with partisan differentials of less than or equal to 5%. "
+"'Generally' competitive districts are districts with partisan differentials "
+"of greater than 5% but less than 10%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:285
 msgid "plan_contiguous short label"
-msgstr "Contiguo"
+msgstr "Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:285
 msgid "plan_contiguous label"
-msgstr "Contiguo"
+msgstr "Contiguous"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:285
 msgid "plan_contiguous long description"
@@ -1006,17 +997,17 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:443
 msgid "plan_equivalence short label"
-msgstr "Población Igual"
+msgstr "Equal Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:443
 msgid "plan_equivalence label"
-msgstr "Población Igual"
+msgstr "Equal Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:443
 msgid "plan_equivalence long description"
 msgstr ""
-"La puntuación población-igual es la diferencia entre el distrito con "
-"mayor población y el distrito con menor población."
+"The Equipopulation score is the difference between the district with the "
+"highest population and the district with the lowest population."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:260
 msgid "plan_hispvap_thresh short label"
@@ -1032,21 +1023,20 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:486
 msgid "plan_majority_minority short label"
-msgstr "Distrito de Mayoría Minoritaria"
+msgstr "Majority Minority District"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:486
 msgid "plan_majority_minority label"
-msgstr "Distrito de Mayoría Minoritaria"
+msgstr "Majority Minority District"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:486
 msgid "plan_majority_minority long description"
 msgstr ""
-"El cumplimento de la Ley de Derechos Electorales será asumido si los "
-"mapas incluyen un distrito de mayoría minoritaria en cualquier área en"
-" que un grupo minoritario es (como se describe en Thornberg V. "
-"Gingles, 478 EEUU 30, 49 (1986)) suficientemente grande y "
-"geográficamente compacto para constituir una mayoría en un distrito "
-"uninominal."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 msgid "plan_majority_minority_blk short label"
 msgstr "VAP Mayoría de Negros (>50%)"
@@ -1056,92 +1046,87 @@ msgstr "VAP Mayoría de Negros (>50%)"
 
 msgid "plan_majority_minority_blk long description"
 msgstr ""
-"El cumplimento de la Ley de Derechos Electorales será asumido si los "
-"mapas incluyen un distrito de mayoría minoritaria en cualquier área en"
-" que un grupo minoritario es (como se describe en Thornberg V. "
-"Gingles, 478 EEUU 30, 49 (1986)) suficientemente grande y "
-"geográficamente compacto para constituir una mayoría en un distrito "
-"uninominal."
+"El cumplimento de la Ley de Derechos Electorales será asumido si los mapas "
+"incluyen un distrito de mayoría minoritaria en cualquier área en que un "
+"grupo minoritario es (como se describe en Thornberg V. Gingles, 478 EEUU 30,"
+" 49 (1986)) suficientemente grande y geográficamente compacto para "
+"constituir una mayoría en un distrito uninominal."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:450
 msgid "plan_majority_minority_blk_congress short label"
-msgstr "VAP Mayoría de Negros (>50%)"
+msgstr "Black VAP Majority (>50%)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:450
 msgid "plan_majority_minority_blk_congress label"
-msgstr "VAP Mayoría de Negros (>50%)"
+msgstr "Black VAP Majority (>50%)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:450
 msgid "plan_majority_minority_blk_congress long description"
 msgstr ""
-"El cumplimento de la Ley de Derechos Electorales será asumido si los "
-"mapas incluyen un distrito de mayoría minoritaria en cualquier área en"
-" que un grupo minoritario es (como se describe en Thornberg V. "
-"Gingles, 478 EEUU 30, 49 (1986)) suficientemente grande y "
-"geográficamente compacto para constituir una mayoría en un distrito "
-"uninominal."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:459
 msgid "plan_majority_minority_blk_house short label"
-msgstr "VAP Mayoría de Negros (>50%)"
+msgstr "Black VAP Majority (>50%)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:459
 msgid "plan_majority_minority_blk_house label"
-msgstr "VAP Mayoría de Negros (>50%)"
+msgstr "Black VAP Majority (>50%)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:459
 msgid "plan_majority_minority_blk_house long description"
 msgstr ""
-"El cumplimento de la Ley de Derechos Electorales será asumido si los "
-"mapas incluyen un distrito de mayoría minoritaria en cualquier área en"
-" que un grupo minoritario es (como se describe en Thornberg V. "
-"Gingles, 478 EEUU 30, 49 (1986)) suficientemente grande y "
-"geográficamente compacto para constituir una mayoría en un distrito "
-"uninominal."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:468
 msgid "plan_majority_minority_blk_senate short label"
-msgstr "VAP Mayoría de Negros (>50%)"
+msgstr "Black VAP Majority (>50%)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:468
 msgid "plan_majority_minority_blk_senate label"
-msgstr "VAP Mayoría de Negros (>50%)"
+msgstr "Black VAP Majority (>50%)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:468
 msgid "plan_majority_minority_blk_senate long description"
 msgstr ""
-"El cumplimento de la Ley de Derechos Electorales será asumido si los "
-"mapas incluyen un distrito de mayoría minoritaria en cualquier área en"
-" que un grupo minoritario es (como se describe en Thornberg V. "
-"Gingles, 478 EEUU 30, 49 (1986)) suficientemente grande y "
-"geográficamente compacto para constituir una mayoría en un distrito "
-"uninominal."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:477
 msgid "plan_majority_minority_hisp short label"
-msgstr "VAP Mayoría de Hisp. (>50%)"
+msgstr "Hisp. VAP Majority (>50%)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:477
 msgid "plan_majority_minority_hisp label"
-msgstr "VAP Mayoría de Hisp. (>50%)"
+msgstr "Hisp. VAP Majority (>50%)"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:477
 msgid "plan_majority_minority_hisp long description"
 msgstr ""
-"El cumplimento de la Ley de Derechos Electorales será asumido si los "
-"mapas incluyen un distrito de mayoría minoritaria en cualquier área en"
-" que un grupo minoritario es (como se describe en Thornberg V. "
-"Gingles, 478 EEUU 30, 49 (1986)) suficientemente grande y "
-"geográficamente compacto para constituir una mayoría en un distrito "
-"uninominal."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:278
 msgid "plan_major_minor short label"
-msgstr "Mayoría-Minoría"
+msgstr "Majority-Minority"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:278
 msgid "plan_major_minor label"
-msgstr "Mayoría-Minoría"
+msgstr "Majority-Minority"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:278
 msgid "plan_major_minor long description"
@@ -1161,34 +1146,34 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:496
 msgid "plan_repfairness short label"
-msgstr "Equidad de Representación"
+msgstr "Representational Fairness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:496
 msgid "plan_repfairness label"
-msgstr "Equidad de Representación"
+msgstr "Representational Fairness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:496
 msgid "plan_repfairness long description"
 msgstr ""
-"La equidad de representación es mayor cuando el porcentaje de "
-"distritos que un partido generalmente ganaría (basado en el índice "
-"partidista usado en calcular la competitividad, refleja fielmente el "
-"porcentaje de los votos de ese mismo partido en todo el estado."
+"Representational fairness is increased when the percentage of districts a "
+"party would likely win (based upon the 'partisan index' used to determine "
+"Competitiveness) closely mirrors that party.s percentage of the statewide "
+"vote."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:505
 msgid "plan_schwartzberg short label"
-msgstr "Compacidad Promedia"
+msgstr "Average Compactness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:505
 msgid "plan_schwartzberg label"
-msgstr "Compacidad Promedia"
+msgstr "Average Compactness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:505
 msgid "plan_schwartzberg long description"
 msgstr ""
-"El concurso utiliza la medida de compacidad Schwartzberg Inversa. "
-"Esta medida es una proporción de la circunferencía del círculo cuya "
-"área es igual al área del distrito y el perímetro del distrito."
+"The competition is using the 'Inverse Schwartzberg' compactness measure. "
+"This measure is a ratio of the circumference of the circle whose area is "
+"equal to the area of the district to the perimeter of the district."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:239
 msgid "plan_sum_equipop short label"
@@ -1204,11 +1189,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:621
 msgid "report_score_compactness_lw short label"
-msgstr "Longitud/Anchura"
+msgstr "Length/Width"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:621
 msgid "report_score_compactness_lw label"
-msgstr "Longitud/Anchura"
+msgstr "Length/Width"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:621
 msgid "report_score_compactness_lw long description"
@@ -1240,11 +1225,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:600
 msgid "report_score_majmin_blk short label"
-msgstr "VAP Afro-Americano"
+msgstr "VAP African-American"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:600
 msgid "report_score_majmin_blk label"
-msgstr "VAP Afro-Americano"
+msgstr "VAP African-American"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:600
 msgid "report_score_majmin_blk long description"
@@ -1252,11 +1237,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:610
 msgid "report_score_majmin_hisp short label"
-msgstr "VAP Hispano/Latino"
+msgstr "VAP Hispanic/Latino"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:610
 msgid "report_score_majmin_hisp label"
-msgstr "VAP Hispano/Latino"
+msgstr "VAP Hispanic/Latino"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:610
 msgid "report_score_majmin_hisp long description"
@@ -1264,11 +1249,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:649
 msgid "report_score_party_dem short label"
-msgstr "Demócrata"
+msgstr "Democratic"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:649
 msgid "report_score_party_dem label"
-msgstr "Demócrata"
+msgstr "Democratic"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:649
 msgid "report_score_party_dem long description"
@@ -1276,11 +1261,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:659
 msgid "report_score_party_rep short label"
-msgstr "Republicano"
+msgstr "Republican"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:659
 msgid "report_score_party_rep label"
-msgstr "Republicano"
+msgstr "Republican"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:659
 msgid "report_score_party_rep long description"
@@ -1288,11 +1273,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:545
 msgid "report_score_total_population_congress short label"
-msgstr "Población Igual"
+msgstr "Total Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:545
 msgid "report_score_total_population_congress label"
-msgstr "Población Igual"
+msgstr "Total Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:545
 msgid "report_score_total_population_congress long description"
@@ -1309,11 +1294,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:563
 msgid "report_score_total_population_house short label"
-msgstr "Población Igual"
+msgstr "Total Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:563
 msgid "report_score_total_population_house label"
-msgstr "Población Igual"
+msgstr "Total Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:563
 msgid "report_score_total_population_house long description"
@@ -1321,11 +1306,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:554
 msgid "report_score_total_population_senate short label"
-msgstr "Población Igual"
+msgstr "Total Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:554
 msgid "report_score_total_population_senate label"
-msgstr "Población Igual"
+msgstr "Total Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:554
 msgid "report_score_total_population_senate long description"
@@ -1333,11 +1318,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:670
 msgid "report_score_unassigned short label"
-msgstr "Cuadras sin Asignar"
+msgstr "Unassigned Blocks"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:670
 msgid "report_score_unassigned label"
-msgstr "Cuadras sin Asignar"
+msgstr "Unassigned Blocks"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:670
 msgid "report_score_unassigned long description"
@@ -1345,11 +1330,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:572
 msgid "report_score_vap short label"
-msgstr "Población en Edad de Votar"
+msgstr "Voting Age Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:572
 msgid "report_score_vap label"
-msgstr "Población en Edad de Votar"
+msgstr "Voting Age Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:572
 msgid "report_score_vap long description"
@@ -1357,11 +1342,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:581
 msgid "report_score_vapblk short label"
-msgstr "VAP Afro-Americano"
+msgstr "VAP African-American"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:581
 msgid "report_score_vapblk label"
-msgstr "VAP Afro-Americano"
+msgstr "VAP African-American"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:581
 msgid "report_score_vapblk long description"
@@ -1369,11 +1354,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:590
 msgid "report_score_vaphisp short label"
-msgstr "VAP Hispano/Latino"
+msgstr "VAP Hispanic/Latino"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:590
 msgid "report_score_vaphisp label"
-msgstr "VAP Hispano/Latino"
+msgstr "VAP Hispanic/Latino"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:590
 msgid "report_score_vaphisp long description"
@@ -1381,11 +1366,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:701
 msgid "panel_competitive_mine short label"
-msgstr "Competitividad"
+msgstr "Competitiveness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:701
 msgid "panel_competitive_mine label"
-msgstr "Competitividad"
+msgstr "Competitiveness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:701
 msgid "panel_competitive_mine long description"
@@ -1393,11 +1378,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:709
 msgid "panel_rf_mine short label"
-msgstr "Equidad de Representación"
+msgstr "Representational Fairness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:709
 msgid "panel_rf_mine label"
-msgstr "Equidad de Representación"
+msgstr "Representational Fairness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:709
 msgid "panel_rf_mine long description"
@@ -1405,11 +1390,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:774
 msgid "community_panel_comments short label"
-msgstr "Comentarios sobre el Plan"
+msgstr "Plan Comments"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:774
 msgid "community_panel_comments label"
-msgstr "Comentarios sobre el Plan"
+msgstr "Plan Comments"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:774
 msgid "community_panel_comments long description"
@@ -1417,11 +1402,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:749
 msgid "congresional_panel_info short label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:749
 msgid "congresional_panel_info label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:749
 msgid "congresional_panel_info long description"
@@ -1429,11 +1414,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:715
 msgid "congressional_panel_summary short label"
-msgstr "Resumen del Plan"
+msgstr "Plan Summary"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:715
 msgid "congressional_panel_summary label"
-msgstr "Resumen del Plan"
+msgstr "Plan Summary"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:715
 msgid "congressional_panel_summary long description"
@@ -1441,11 +1426,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:781
 msgid "congressional_panel_demo short label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:781
 msgid "congressional_panel_demo label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:781
 msgid "congressional_panel_demo long description"
@@ -1453,11 +1438,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:757
 msgid "house_panel_info short label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:757
 msgid "house_panel_info label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:757
 msgid "house_panel_info long description"
@@ -1465,11 +1450,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:723
 msgid "house_panel_summary short label"
-msgstr "Resumen del Plan"
+msgstr "Plan Summary"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:723
 msgid "house_panel_summary label"
-msgstr "Resumen del Plan"
+msgstr "Plan Summary"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:723
 msgid "house_panel_summary long description"
@@ -1477,11 +1462,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:789
 msgid "house_panel_demo short label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:789
 msgid "house_panel_demo label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:789
 msgid "house_panel_demo long description"
@@ -1489,11 +1474,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:765
 msgid "senate_panel_info short label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:765
 msgid "senate_panel_info label"
-msgstr "Información Básica"
+msgstr "Basic Information"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:765
 msgid "senate_panel_info long description"
@@ -1501,11 +1486,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:731
 msgid "senate_panel_summary short label"
-msgstr "Resumen del Plan"
+msgstr "Plan Summary"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:731
 msgid "senate_panel_summary label"
-msgstr "Resumen del Plan"
+msgstr "Plan Summary"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:731
 msgid "senate_panel_summary long description"
@@ -1513,11 +1498,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:797
 msgid "senate_panel_demo short label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:797
 msgid "senate_panel_demo label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:797
 msgid "senate_panel_demo long description"
@@ -1552,11 +1537,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:813
 msgid "report_panel_population short label"
-msgstr "Población"
+msgstr "Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:813
 msgid "report_panel_population label"
-msgstr "Población"
+msgstr "Population"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:813
 msgid "report_panel_population long description"
@@ -1564,11 +1549,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:805
 msgid "community_panel_demo short label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:805
 msgid "community_panel_demo label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:805
 msgid "community_panel_demo long description"
@@ -1576,11 +1561,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:739
 msgid "community_panel_summary short label"
-msgstr "Resumen de la Comunidad"
+msgstr "Community Summary"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:739
 msgid "community_panel_summary label"
-msgstr "Resumen de la Comunidad"
+msgstr "Community Summary"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:739
 msgid "community_panel_summary long description"
@@ -1588,11 +1573,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:824
 msgid "report_panel_majmin short label"
-msgstr "Distritos de Mayoría Minoritaria"
+msgstr "Majority Minority Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:824
 msgid "report_panel_majmin label"
-msgstr "Distritos de Mayoría Minoritaria"
+msgstr "Majority Minority Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:824
 msgid "report_panel_majmin long description"
@@ -1600,11 +1585,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:831
 msgid "report_panel_compactness short label"
-msgstr "Compacidad"
+msgstr "Compactness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:831
 msgid "report_panel_compactness label"
-msgstr "Compacidad"
+msgstr "Compactness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:831
 msgid "report_panel_compactness long description"
@@ -1612,11 +1597,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:839
 msgid "report_panel_party short label"
-msgstr "Distrito(s) Controlado(s) por un Partido"
+msgstr "Party-Controlled Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:839
 msgid "report_panel_party label"
-msgstr "Distrito(s) Controlado(s) por un Partido"
+msgstr "Party-Controlled Districts"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:839
 msgid "report_panel_party long description"
@@ -1624,11 +1609,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:846
 msgid "report_panel_spatial short label"
-msgstr "Análisis Espacial"
+msgstr "Spatial Analysis"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:846
 msgid "report_panel_spatial label"
-msgstr "Análisis Espacial"
+msgstr "Spatial Analysis"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:846
 msgid "report_panel_spatial long description"
@@ -1636,11 +1621,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:679
 msgid "panel_equipop_all short label"
-msgstr "Población-Igual"
+msgstr "Equipopulation"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:679
 msgid "panel_equipop_all label"
-msgstr "Población-Igual"
+msgstr "Equipopulation"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:679
 msgid "panel_equipop_all long description"
@@ -1660,11 +1645,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:697
 msgid "panel_competitive_all short label"
-msgstr "Competitividad"
+msgstr "Competitiveness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:697
 msgid "panel_competitive_all label"
-msgstr "Competitividad"
+msgstr "Competitiveness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:697
 msgid "panel_competitive_all long description"
@@ -1672,11 +1657,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:705
 msgid "panel_rf_all short label"
-msgstr "Equidad de Representación"
+msgstr "Representational Fairness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:705
 msgid "panel_rf_all label"
-msgstr "Equidad de Representación"
+msgstr "Representational Fairness"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:705
 msgid "panel_rf_all long description"
@@ -1684,11 +1669,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:683
 msgid "panel_equipop_mine short label"
-msgstr "Población-Igual"
+msgstr "Equipopulation"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:683
 msgid "panel_equipop_mine label"
-msgstr "Población-Igual"
+msgstr "Equipopulation"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:683
 msgid "panel_equipop_mine long description"
@@ -1967,11 +1952,11 @@ msgstr "TodosContiguos - Casa"
 msgid "house_contiguity long description"
 msgstr ""
 "<p>Su plan no cumple con los criterios de concurso para "
-"contigüidad</p><p>Todos los distritos dentro de un plan deben ser "
-"contiguos. La contigüidad del agua es permitida debido a la extensa "
-"región costera que posee Virginia. Contigüidad por punto o "
-"contigüidad por toque de punto donde dos secciones de un distrito "
-"están conectadas en un solo punto no está permitido. </p>"
+"contigüidad</p><p>Todos los distritos dentro de un plan deben ser contiguos."
+" La contigüidad del agua es permitida debido a la extensa región costera que"
+" posee Virginia. Contigüidad por punto o contigüidad por toque de punto "
+"donde dos secciones de un distrito están conectadas en un solo punto no está"
+" permitido. </p>"
 
 msgid "house_majority_minority short label"
 msgstr "MayoríaMinoría - Casa"
@@ -2027,8 +2012,8 @@ msgstr "Población-Igual - Congreso"
 msgid "congress_equipop long description"
 msgstr ""
 "<p>Su plan no cumple con los criterios del concurso para Población-"
-"Igual:</p><p>La población de cada distrito del Congreso debe ser "
-"727,366 +/- 0.5%.</p>"
+"Igual:</p><p>La población de cada distrito del Congreso debe ser 727,366 +/-"
+" 0.5%.</p>"
 
 msgid "congress_contiguity short label"
 msgstr "TodosContiguos - Congreso"
@@ -2039,11 +2024,11 @@ msgstr "TodosContiguos - Congreso"
 msgid "congress_contiguity long description"
 msgstr ""
 "<p>Su plan no cumple con los criterios de concurso para "
-"contigüidad</p><p>Todos los distritos dentro de un plan deben ser "
-"contiguos. La contigüidad del agua es permitida debido a la extensa "
-"región costera que posee Virginia. Contigüidad por punto o "
-"contigüidad por toque de punto donde dos secciones de un distrito "
-"están conectadas en un solo punto no está permitido. </p>"
+"contigüidad</p><p>Todos los distritos dentro de un plan deben ser contiguos."
+" La contigüidad del agua es permitida debido a la extensa región costera que"
+" posee Virginia. Contigüidad por punto o contigüidad por toque de punto "
+"donde dos secciones de un distrito están conectadas en un solo punto no está"
+" permitido. </p>"
 
 msgid "congress_majority_minority short label"
 msgstr "MayoríaMinoría - Congreso"
@@ -2081,8 +2066,8 @@ msgstr "Población-Igual - Casa"
 msgid "house_equipop long description"
 msgstr ""
 "<p>Su plan no cumple con los criterios del concurso para Población-"
-"Igual:</p><p>La población de cada distrito de la Casa de Delegados "
-"debe ser 80,010 +/- 5%.</p>"
+"Igual:</p><p>La población de cada distrito de la Casa de Delegados debe ser "
+"80,010 +/- 5%.</p>"
 
 msgid "senate_equipop short label"
 msgstr "Población-Igual - Senado"
@@ -2093,8 +2078,8 @@ msgstr "Población-Igual - Senado"
 msgid "senate_equipop long description"
 msgstr ""
 "<p>Su plan no cumple con los criterios del concurso para Población-"
-"Igual:</p><p>La población de cada distrito de la Casa de Delegados "
-"debe ser 80,010 +/- 5%.</p>"
+"Igual:</p><p>La población de cada distrito de la Casa de Delegados debe ser "
+"80,010 +/- 5%.</p>"
 
 msgid "senate_contiguity short label"
 msgstr "TodosContiguos - Senado"
@@ -2105,11 +2090,11 @@ msgstr "TodosContiguos - Senado"
 msgid "senate_contiguity long description"
 msgstr ""
 "<p>Su plan no cumple con los criterios de concurso para "
-"contigüidad</p><p>Todos los distritos dentro de un plan deben ser "
-"contiguos. La contigüidad del agua es permitida debido a la extensa "
-"región costera que posee Virginia. Contigüidad por punto o "
-"contigüidad por toque de punto donde dos secciones de un distrito "
-"están conectadas en un solo punto no está permitido. </p>"
+"contigüidad</p><p>Todos los distritos dentro de un plan deben ser contiguos."
+" La contigüidad del agua es permitida debido a la extensa región costera que"
+" posee Virginia. Contigüidad por punto o contigüidad por toque de punto "
+"donde dos secciones de un distrito están conectadas en un solo punto no está"
+" permitido. </p>"
 
 msgid "senate_all_assigned short label"
 msgstr "TodasLasCuadrasAsignadas - Senado"
@@ -2284,44 +2269,44 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:969
 msgid "congress-equipop short label"
-msgstr "Población-Igual - Congreso"
+msgstr "Equipopulation - Congress"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:969
 msgid "congress-equipop label"
-msgstr "Población-Igual - Congreso"
+msgstr "Equipopulation - Congress"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:969
 msgid "congress-equipop long description"
 msgstr ""
-"<p>Su plan no cumple con los criterios del concurso para Población-"
-"Igual:</p><p>La población de cada distrito del Congreso debe ser "
+"<p>Your plan does not meet the competition criteria for "
+"Equipopulation:</p><p>The population of each Congressional district must be "
 "727,366 +/- 0.5%.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:973
 msgid "congress-contiguous short label"
-msgstr "TodosContiguos - Congreso"
+msgstr "AllContiguous - Congress"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:973
 msgid "congress-contiguous label"
-msgstr "TodosContiguos - Congreso"
+msgstr "AllContiguous - Congress"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:973
 msgid "congress-contiguous long description"
 msgstr ""
-"<p>Su plan no cumple con los criterios de concurso para "
-"contigüidad</p><p>Todos los distritos dentro de un plan deben ser "
-"contiguos. La contigüidad del agua es permitida debido a la extensa "
-"región costera que posee Virginia. Contigüidad por punto o "
-"contigüidad por toque de punto donde dos secciones de un distrito "
-"están conectadas en un solo punto no está permitido. </p>"
+"<p>Your plan does not meet the competition criteria for "
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:976
 msgid "congress-major-minor short label"
-msgstr "MayoríaMinoría - Congreso"
+msgstr "MajorityMinority - Congress"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:976
 msgid "congress-major-minor label"
-msgstr "MayoríaMinoría - Congreso"
+msgstr "MajorityMinority - Congress"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:976
 msgid "congress-major-minor long description"
@@ -2329,11 +2314,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:979
 msgid "congress-district-count short label"
-msgstr "ContarDistritos - Congreso"
+msgstr "CountDistricts - Congress"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:979
 msgid "congress-district-count label"
-msgstr "ContarDistritos - Congreso"
+msgstr "CountDistricts - Congress"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:979
 msgid "congress-district-count long description"
@@ -2341,11 +2326,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:982
 msgid "congress-assigned short label"
-msgstr "TodasLasCuadrasAsignadas - Congreso"
+msgstr "AllBlocksAssigned - Congress"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:982
 msgid "congress-assigned label"
-msgstr "TodasLasCuadrasAsignadas - Congreso"
+msgstr "AllBlocksAssigned - Congress"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:982
 msgid "congress-assigned long description"
@@ -2353,44 +2338,44 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:988
 msgid "house-equipop short label"
-msgstr "Población-Igual - Casa"
+msgstr "Equipopulation - House"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:988
 msgid "house-equipop label"
-msgstr "Población-Igual - Casa"
+msgstr "Equipopulation - House"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:988
 msgid "house-equipop long description"
 msgstr ""
-"<p>Su plan no cumple con los criterios del concurso para Población-"
-"Igual:</p><p>La población de cada distrito de la Casa de Delegados "
-"debe ser 80,010 +/- 5%.</p>"
+"<p>Your plan does not meet the competition criteria for "
+"Equipopulation:</p><p>The population of each House of Delegates district "
+"must be 80,010 +/- 5%.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:992
 msgid "house-contiguous short label"
-msgstr "TodosContiguos - Casa"
+msgstr "AllContiguous - House"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:992
 msgid "house-contiguous label"
-msgstr "TodosContiguos - Casa"
+msgstr "AllContiguous - House"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:992
 msgid "house-contiguous long description"
 msgstr ""
-"<p>Su plan no cumple con los criterios de concurso para "
-"contigüidad</p><p>Todos los distritos dentro de un plan deben ser "
-"contiguos. La contigüidad del agua es permitida debido a la extensa "
-"región costera que posee Virginia. Contigüidad por punto o "
-"contigüidad por toque de punto donde dos secciones de un distrito "
-"están conectadas en un solo punto no está permitido. </p>"
+"<p>Your plan does not meet the competition criteria for "
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:995
 msgid "house-major-minor short label"
-msgstr "MayoríaMinoría - Casa"
+msgstr "MajorityMinority - House"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:995
 msgid "house-major-minor label"
-msgstr "MayoríaMinoría - Casa"
+msgstr "MajorityMinority - House"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:995
 msgid "house-major-minor long description"
@@ -2398,11 +2383,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:998
 msgid "house-district-count short label"
-msgstr "ContarDistritos - Casa"
+msgstr "CountDistricts - House"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:998
 msgid "house-district-count label"
-msgstr "ContarDistritos - Casa"
+msgstr "CountDistricts - House"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:998
 msgid "house-district-count long description"
@@ -2410,11 +2395,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1001
 msgid "house-assigned short label"
-msgstr "TodasLasCuadrasAsignadas - Casa"
+msgstr "AllBlocksAssigned - House"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1001
 msgid "house-assigned label"
-msgstr "TodasLasCuadrasAsignadas - Casa"
+msgstr "AllBlocksAssigned - House"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1001
 msgid "house-assigned long description"
@@ -2422,11 +2407,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1014
 msgid "senate-major-minor short label"
-msgstr "MayoríaMinoría - Senado"
+msgstr "MajorityMinority - Senate"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1014
 msgid "senate-major-minor label"
-msgstr "MayoríaMinoría - Senado"
+msgstr "MajorityMinority - Senate"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1014
 msgid "senate-major-minor long description"
@@ -2434,11 +2419,11 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1017
 msgid "senate-district-count short label"
-msgstr "ContarDistritos - Senado"
+msgstr "CountDistricts - Senate"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1017
 msgid "senate-district-count label"
-msgstr "ContarDistritos - Senado"
+msgstr "CountDistricts - Senate"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1017
 msgid "senate-district-count long description"
@@ -2446,44 +2431,44 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1007
 msgid "senate-equipop short label"
-msgstr "Población-Igual - Senado"
+msgstr "Equipopulation - Senate"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1007
 msgid "senate-equipop label"
-msgstr "Población-Igual - Senado"
+msgstr "Equipopulation - Senate"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1007
 msgid "senate-equipop long description"
 msgstr ""
-"<p>Su plan no cumple con los criterios del concurso para Población-"
-"Igual:</p><p>La población de cada distrito de la Casa de Delegados "
-"debe ser 80,010 +/- 5%.</p>"
+"<p>Your plan does not meet the competition criteria for "
+"Equipopulation:</p><p>The population of each House of Delegates district "
+"must be 200,026 +/- 5%.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1011
 msgid "senate-contiguous short label"
-msgstr "TodosContiguos - Senado"
+msgstr "AllContiguous - Senate"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1011
 msgid "senate-contiguous label"
-msgstr "TodosContiguos - Senado"
+msgstr "AllContiguous - Senate"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1011
 msgid "senate-contiguous long description"
 msgstr ""
-"<p>Su plan no cumple con los criterios de concurso para "
-"contigüidad</p><p>Todos los distritos dentro de un plan deben ser "
-"contiguos. La contigüidad del agua es permitida debido a la extensa "
-"región costera que posee Virginia. Contigüidad por punto o "
-"contigüidad por toque de punto donde dos secciones de un distrito "
-"están conectadas en un solo punto no está permitido. </p>"
+"<p>Your plan does not meet the competition criteria for "
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1020
 msgid "senate-assigned short label"
-msgstr "TodasLasCuadrasAsignadas - Senado"
+msgstr "AllBlocksAssigned - Senate"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1020
 msgid "senate-assigned label"
-msgstr "TodasLasCuadrasAsignadas - Senado"
+msgstr "AllBlocksAssigned - Senate"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1020
 msgid "senate-assigned long description"
@@ -2500,11 +2485,11 @@ msgstr "The District of Columbia Metropolitan Area"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:926
 msgid "community_sidebar_demo short label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:926
 msgid "community_sidebar_demo label"
-msgstr "Demografía"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:926
 msgid "community_sidebar_demo long description"
@@ -2512,13 +2497,24 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:931
 msgid "community_sidebar_comments short label"
-msgstr "Mapeo de Comunidad"
+msgstr "Community Mapping"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:931
 msgid "community_sidebar_comments label"
-msgstr "Mapeo de Comunidad"
+msgstr "Community Mapping"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:931
 msgid "community_sidebar_comments long description"
 msgstr ""
 
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio short label"
+msgstr "Convex Hull Ratio"
+
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio label"
+msgstr "Convex Hull Ratio"
+
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio long description"
+msgstr ""

--- a/django/publicmapping/locale/fr/LC_MESSAGES/xmlconfig.po
+++ b/django/publicmapping/locale/fr/LC_MESSAGES/xmlconfig.po
@@ -7,10 +7,10 @@ msgstr ""
 "PO-Revision-Date: 2012-01-14 01:47+0000\n"
 "Last-Translator: admin <dzwarg+admin@azavea.com>\n"
 "Language-Team: admin <dzwarg+admin@azavea.com>\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:10
 msgid "congress short label"
@@ -134,27 +134,27 @@ msgstr "Communities"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:63
 msgid "dc_vtd short label"
-msgstr "VTD"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:63
 msgid "dc_vtd label"
-msgstr "VTD"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:63
 msgid "dc_vtd long description"
-msgstr "Voter Tabulation Districts"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:62
 msgid "dc_block short label"
-msgstr "block"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:62
 msgid "dc_block label"
-msgstr "Block"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:62
 msgid "dc_block long description"
-msgstr "Census Blocks"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1142
 msgid "county short label"
@@ -162,47 +162,47 @@ msgstr "county"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1142
 msgid "county label"
-msgstr "County"
+msgstr "county"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1142
 msgid "county long description"
-msgstr "Counties"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:37
 msgid "va_block short label"
-msgstr "block"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:37
 msgid "va_block label"
-msgstr "Block"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:37
 msgid "va_block long description"
-msgstr "Census Blocks"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:38
 msgid "va_vtd short label"
-msgstr "vtd"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:38
 msgid "va_vtd label"
-msgstr "VTD"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:38
 msgid "va_vtd long description"
-msgstr "Voter Tabulation Districts"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:39
 msgid "va_county short label"
-msgstr "county"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:39
 msgid "va_county label"
-msgstr "County"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:39
 msgid "va_county long description"
-msgstr "Counties"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1088
 msgid "vtd short label"
@@ -210,11 +210,11 @@ msgstr "vtd"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1088
 msgid "vtd label"
-msgstr "VTD"
+msgstr "vtd"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1088
 msgid "vtd long description"
-msgstr "Voter Tabulation Districts"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1027
 msgid "block short label"
@@ -222,11 +222,11 @@ msgstr "block"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1027
 msgid "block label"
-msgstr "Block"
+msgstr "block"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1027
 msgid "block long description"
-msgstr "Census Blocks"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:853
 msgid "congress_leader_all short label"
@@ -494,8 +494,7 @@ msgstr "Count Districts"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:342
 msgid "a_congress_plan_count_districts long description"
 msgstr ""
-"The number of districts in a Congressional redistricting plan must be "
-"11."
+"The number of districts in a Congressional redistricting plan must be 11."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:373
 msgid "a_congress_plan_equipopulation_summary short label"
@@ -508,8 +507,7 @@ msgstr "Target Pop. (727,366)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:373
 msgid "a_congress_plan_equipopulation_summary long description"
 msgstr ""
-"The population of each Congressional district must be 727,366 +/- "
-"0.5%."
+"The population of each Congressional district must be 727,366 +/- 0.5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:363
 msgid "a_congress_plan_equipopulation_validation short label"
@@ -522,8 +520,7 @@ msgstr "Target Pop. (727,366)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:363
 msgid "a_congress_plan_equipopulation_validation long description"
 msgstr ""
-"The population of each Congressional district must be 727,366 +/- "
-"0.5%."
+"The population of each Congressional district must be 727,366 +/- 0.5%."
 
 msgid "a_dc_area_council_plan_equipopulation_summary short label"
 msgstr "Pop. cible (292843)"
@@ -533,8 +530,8 @@ msgstr "Pop. cible (292843)"
 
 msgid "a_dc_area_council_plan_equipopulation_summary long description"
 msgstr ""
-"La population de chaque circonscription du Sénat de l'État doit être "
-"292843 +/-5 %."
+"La population de chaque circonscription du Sénat de l'État doit être 292843 "
+"+/-5 %."
 
 msgid "a_dc_area_council_plan_equipopulation_validation short label"
 msgstr "Pop. cible (292843)"
@@ -544,8 +541,8 @@ msgstr "Pop. cible (292843)"
 
 msgid "a_dc_area_council_plan_equipopulation_validation long description"
 msgstr ""
-"La population de chaque circonscription du Sénat de l'État doit être "
-"292843 +/-5 %."
+"La population de chaque circonscription du Sénat de l'État doit être 292843 "
+"+/-5 %."
 
 msgid "a_dc_area_council_population short label"
 msgstr "Pop tot"
@@ -567,8 +564,8 @@ msgstr "Count Districts"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:349
 msgid "a_house_plan_count_districts long description"
 msgstr ""
-"The number of districts in a House of Delegates redistricting plan "
-"must be 100."
+"The number of districts in a House of Delegates redistricting plan must be "
+"100."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:393
 msgid "a_house_plan_equipopulation_summary short label"
@@ -581,8 +578,7 @@ msgstr "Target Pop. (80,010)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:393
 msgid "a_house_plan_equipopulation_summary long description"
 msgstr ""
-"The population of each House of Delegates district must be 80,010 +/- "
-"5%."
+"The population of each House of Delegates district must be 80,010 +/- 5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:383
 msgid "a_house_plan_equipopulation_validation short label"
@@ -595,8 +591,7 @@ msgstr "Target Pop. (80,010)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:383
 msgid "a_house_plan_equipopulation_validation long description"
 msgstr ""
-"The population of each House of Delegates district must be 80,010 +/- "
-"5%."
+"The population of each House of Delegates district must be 80,010 +/- 5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:321
 msgid "a_house_population short label"
@@ -621,8 +616,7 @@ msgstr "Count Districts"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:356
 msgid "a_senate_plan_count_districts long description"
 msgstr ""
-"The number of districts in a State Senate redistricting plan must be "
-"100."
+"The number of districts in a State Senate redistricting plan must be 100."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:413
 msgid "a_senate_plan_equipopulation_summary short label"
@@ -920,12 +914,12 @@ msgstr "All Contiguous"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:429
 msgid "plan_all_contiguous long description"
 msgstr ""
-"Contiguity means that every part of a district must be reachable from "
-"every other part without crossing the district's borders. All "
-"districts within a plan must be contiguous. Water contiguity is "
-"permitted given Virginia's extensive coastal region. 'Point "
-"contiguity' or 'touch-point contiguity' where two sections of a "
-"district are connected at a single point is not permitted."
+"Contiguity means that every part of a district must be reachable from every "
+"other part without crossing the district's borders. All districts within a "
+"plan must be contiguous. Water contiguity is permitted given Virginia's "
+"extensive coastal region. 'Point contiguity' or 'touch-point contiguity' "
+"where two sections of a district are connected at a single point is not "
+"permitted."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:243
 msgid "plan_all_equipop short label"
@@ -962,14 +956,13 @@ msgstr "Competitiveness"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:435
 msgid "plan_competitiveness long description"
 msgstr ""
-"Each plan's overall political competitiveness is determined by "
-"averaging each district.s 'partisan differential'.  The partisan "
-"differential of each district is calculated by subtracting the "
-"Democratic 'partisan index' from the Republican 'partisan "
-"index'.<br/><br/>'Heavily' competitive districts are districts with "
-"partisan differentials of less than or equal to 5%. 'Generally' "
-"competitive districts are districts with partisan differentials of "
-"greater than 5% but less than 10%."
+"Each plan's overall political competitiveness is determined by averaging "
+"each district.s 'partisan differential'.  The partisan differential of each "
+"district is calculated by subtracting the Democratic 'partisan index' from "
+"the Republican 'partisan index'.<br/><br/>'Heavily' competitive districts "
+"are districts with partisan differentials of less than or equal to 5%. "
+"'Generally' competitive districts are districts with partisan differentials "
+"of greater than 5% but less than 10%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:285
 msgid "plan_contiguous short label"
@@ -1006,8 +999,8 @@ msgstr "Equal Population"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:443
 msgid "plan_equivalence long description"
 msgstr ""
-"The Equipopulation score is the difference between the district with "
-"the highest population and the district with the lowest population."
+"The Equipopulation score is the difference between the district with the "
+"highest population and the district with the lowest population."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:260
 msgid "plan_hispvap_thresh short label"
@@ -1032,11 +1025,11 @@ msgstr "Majority Minority District"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:486
 msgid "plan_majority_minority long description"
 msgstr ""
-"Compliance with the Voting Rights Act will be assumed if maps include "
-"a minority-majority district in any area where a minority group is (as"
-" described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) "
-"'sufficiently large and geographically compact to constitute a "
-"majority in a single-member district'."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 msgid "plan_majority_minority_blk short label"
 msgstr "Majorité de VAP noire (>50%)"
@@ -1047,11 +1040,10 @@ msgstr "Majorité de VAP noire (>50%)"
 msgid "plan_majority_minority_blk long description"
 msgstr ""
 "Le respect de la Loi des droits de vote sera supposé si les cartes "
-"comprennent une circonscription de minorité-majorité dans toutes zones"
-" où un groupe minoritaire est (comme décrit dans Thornburg V. Gingles,"
-" 478 U.S. 30, 49 (1986)) 'suffisamment grand et géographiquement "
-"compact pour constituer une majorité dans une circonscription "
-"uninominale'."
+"comprennent une circonscription de minorité-majorité dans toutes zones où un"
+" groupe minoritaire est (comme décrit dans Thornburg V. Gingles, 478 U.S. "
+"30, 49 (1986)) 'suffisamment grand et géographiquement compact pour "
+"constituer une majorité dans une circonscription uninominale'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:450
 msgid "plan_majority_minority_blk_congress short label"
@@ -1064,11 +1056,11 @@ msgstr "Black VAP Majority (>50%)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:450
 msgid "plan_majority_minority_blk_congress long description"
 msgstr ""
-"Compliance with the Voting Rights Act will be assumed if maps include "
-"a minority-majority district in any area where a minority group is (as"
-" described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) "
-"'sufficiently large and geographically compact to constitute a "
-"majority in a single-member district'."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:459
 msgid "plan_majority_minority_blk_house short label"
@@ -1081,11 +1073,11 @@ msgstr "Black VAP Majority (>50%)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:459
 msgid "plan_majority_minority_blk_house long description"
 msgstr ""
-"Compliance with the Voting Rights Act will be assumed if maps include "
-"a minority-majority district in any area where a minority group is (as"
-" described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) "
-"'sufficiently large and geographically compact to constitute a "
-"majority in a single-member district'."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:468
 msgid "plan_majority_minority_blk_senate short label"
@@ -1098,11 +1090,11 @@ msgstr "Black VAP Majority (>50%)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:468
 msgid "plan_majority_minority_blk_senate long description"
 msgstr ""
-"Compliance with the Voting Rights Act will be assumed if maps include "
-"a minority-majority district in any area where a minority group is (as"
-" described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) "
-"'sufficiently large and geographically compact to constitute a "
-"majority in a single-member district'."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:477
 msgid "plan_majority_minority_hisp short label"
@@ -1115,11 +1107,11 @@ msgstr "Hisp. VAP Majority (>50%)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:477
 msgid "plan_majority_minority_hisp long description"
 msgstr ""
-"Compliance with the Voting Rights Act will be assumed if maps include "
-"a minority-majority district in any area where a minority group is (as"
-" described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) "
-"'sufficiently large and geographically compact to constitute a "
-"majority in a single-member district'."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:278
 msgid "plan_major_minor short label"
@@ -1156,10 +1148,10 @@ msgstr "Representational Fairness"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:496
 msgid "plan_repfairness long description"
 msgstr ""
-"Representational fairness is increased when the percentage of "
-"districts a party would likely win (based upon the 'partisan index' "
-"used to determine Competitiveness) closely mirrors that party.s "
-"percentage of the statewide vote."
+"Representational fairness is increased when the percentage of districts a "
+"party would likely win (based upon the 'partisan index' used to determine "
+"Competitiveness) closely mirrors that party.s percentage of the statewide "
+"vote."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:505
 msgid "plan_schwartzberg short label"
@@ -1172,10 +1164,9 @@ msgstr "Average Compactness"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:505
 msgid "plan_schwartzberg long description"
 msgstr ""
-"The competition is using the 'Inverse Schwartzberg' compactness "
-"measure. This measure is a ratio of the circumference of the circle "
-"whose area is equal to the area of the district to the perimeter of "
-"the district."
+"The competition is using the 'Inverse Schwartzberg' compactness measure. "
+"This measure is a ratio of the circumference of the circle whose area is "
+"equal to the area of the district to the perimeter of the district."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:239
 msgid "plan_sum_equipop short label"
@@ -1951,14 +1942,13 @@ msgstr "Tous contigus - Chambre"
 msgid "house_contiguity long description"
 msgstr ""
 "<p>Votre plan ne respecte pas les critères de concurrence de "
-"Contiguïté</p><p>Chaque partie d'une circonscription doit être "
-"accessible depuis toutes les autres parties sans quitter les "
-"frontières de la circonscription. Toutes les circonscriptions au sein "
-"d'un plan doivent être contiguës. La contiguïté de l'eau est  "
-"autorisée compte tenu de la vaste région côtière de la Virginie. "
-"'Point de contiguïté' ou 'point de contact de contiguïté' où deux "
-"sections d'une circonscription sont connectées à un seul point n'est "
-"pas autorisé.</p>"
+"Contiguïté</p><p>Chaque partie d'une circonscription doit être accessible "
+"depuis toutes les autres parties sans quitter les frontières de la "
+"circonscription. Toutes les circonscriptions au sein d'un plan doivent être "
+"contiguës. La contiguïté de l'eau est  autorisée compte tenu de la vaste "
+"région côtière de la Virginie. 'Point de contiguïté' ou 'point de contact de"
+" contiguïté' où deux sections d'une circonscription sont connectées à un "
+"seul point n'est pas autorisé.</p>"
 
 msgid "house_majority_minority short label"
 msgstr "MajoritéMinorité - Chambre"
@@ -2013,9 +2003,9 @@ msgstr "Population-égale  - Congrès"
 
 msgid "congress_equipop long description"
 msgstr ""
-"<p> votre plan ne respecte pas les critères de concurrence d'égalité "
-"de la population:</p><p>La population de chaque circonscription du "
-"Congrès doit être 727366 +/-0,5%.</p>"
+"<p> votre plan ne respecte pas les critères de concurrence d'égalité de la "
+"population:</p><p>La population de chaque circonscription du Congrès doit "
+"être 727366 +/-0,5%.</p>"
 
 msgid "congress_contiguity short label"
 msgstr "Tous contigus - Congrès"
@@ -2026,14 +2016,13 @@ msgstr "Tous contigus - Congrès"
 msgid "congress_contiguity long description"
 msgstr ""
 "<p>Votre plan ne respecte pas les critères de concurrence de "
-"Contiguïté</p><p>Chaque partie d'une circonscription doit être "
-"accessible depuis toutes les autres parties sans quitter les "
-"frontières de la circonscription. Toutes les circonscriptions au sein "
-"d'un plan doivent être contiguës. La contiguïté de l'eau est  "
-"autorisée compte tenu de la vaste région côtière de la Virginie. "
-"'Point de contiguïté' ou 'point de contact de contiguïté' où deux "
-"sections d'une circonscription sont connectées à un seul point n'est "
-"pas autorisé.</p>"
+"Contiguïté</p><p>Chaque partie d'une circonscription doit être accessible "
+"depuis toutes les autres parties sans quitter les frontières de la "
+"circonscription. Toutes les circonscriptions au sein d'un plan doivent être "
+"contiguës. La contiguïté de l'eau est  autorisée compte tenu de la vaste "
+"région côtière de la Virginie. 'Point de contiguïté' ou 'point de contact de"
+" contiguïté' où deux sections d'une circonscription sont connectées à un "
+"seul point n'est pas autorisé.</p>"
 
 msgid "congress_majority_minority short label"
 msgstr "MajoritéMinorité - Congrès"
@@ -2070,9 +2059,9 @@ msgstr "Population-égale - Chambre"
 
 msgid "house_equipop long description"
 msgstr ""
-"<p> votre plan ne respecte pas les critères de concurrence d'égalité "
-"de la population:</p><p>La population de chaque circonscription de la "
-"Chambre des délégués doit être 80010 +/-5%.</p>"
+"<p> votre plan ne respecte pas les critères de concurrence d'égalité de la "
+"population:</p><p>La population de chaque circonscription de la Chambre des "
+"délégués doit être 80010 +/-5%.</p>"
 
 msgid "senate_equipop short label"
 msgstr "Population-égale - Sénat"
@@ -2082,9 +2071,9 @@ msgstr "Population-égale - Sénat"
 
 msgid "senate_equipop long description"
 msgstr ""
-"<p> votre plan ne respecte pas les critères de concurrence d'égalité "
-"de la population:</p><p>La population de chaque circonscription de la "
-"Chambre des délégués doit être 200026 +/-5%.</p>"
+"<p> votre plan ne respecte pas les critères de concurrence d'égalité de la "
+"population:</p><p>La population de chaque circonscription de la Chambre des "
+"délégués doit être 200026 +/-5%.</p>"
 
 msgid "senate_contiguity short label"
 msgstr "Tous contigus - Sénat"
@@ -2095,14 +2084,13 @@ msgstr "Tous contigus - Sénat"
 msgid "senate_contiguity long description"
 msgstr ""
 "<p>Votre plan ne respecte pas les critères de concurrence de "
-"Contiguïté</p><p>Chaque partie d'une circonscription doit être "
-"accessible depuis toutes les autres parties sans quitter les "
-"frontières de la circonscription. Toutes les circonscriptions au sein "
-"d'un plan doivent être contiguës. La contiguïté de l'eau est  "
-"autorisée compte tenu de la vaste région côtière de la Virginie. "
-"'Point de contiguïté' ou 'point de contact de contiguïté' où deux "
-"sections d'une circonscription sont connectées à un seul point n'est "
-"pas autorisé.</p>"
+"Contiguïté</p><p>Chaque partie d'une circonscription doit être accessible "
+"depuis toutes les autres parties sans quitter les frontières de la "
+"circonscription. Toutes les circonscriptions au sein d'un plan doivent être "
+"contiguës. La contiguïté de l'eau est  autorisée compte tenu de la vaste "
+"région côtière de la Virginie. 'Point de contiguïté' ou 'point de contact de"
+" contiguïté' où deux sections d'une circonscription sont connectées à un "
+"seul point n'est pas autorisé.</p>"
 
 msgid "senate_all_assigned short label"
 msgstr "Tous les blocs attribués - Sénat"
@@ -2278,8 +2266,8 @@ msgstr "Equipopulation - Congress"
 msgid "congress-equipop long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Equipopulation:</p><p>The population of each Congressional district "
-"must be 727,366 +/- 0.5%.</p>"
+"Equipopulation:</p><p>The population of each Congressional district must be "
+"727,366 +/- 0.5%.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:973
 msgid "congress-contiguous short label"
@@ -2293,12 +2281,11 @@ msgstr "AllContiguous - Congress"
 msgid "congress-contiguous long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Contiguity</p><p>Every part of a district must be reachable from every"
-" other part without crossing the district's borders. All districts "
-"within a plan must be contiguous. Water contiguity is permitted given "
-"Virginia's extensive coastal region. 'Point contiguity' or 'touch-"
-"point contiguity' where two sections of a district are connected at a "
-"single point is not permitted.</p>"
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:976
 msgid "congress-major-minor short label"
@@ -2348,8 +2335,8 @@ msgstr "Equipopulation - House"
 msgid "house-equipop long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Equipopulation:</p><p>The population of each House of Delegates "
-"district must be 80,010 +/- 5%.</p>"
+"Equipopulation:</p><p>The population of each House of Delegates district "
+"must be 80,010 +/- 5%.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:992
 msgid "house-contiguous short label"
@@ -2363,12 +2350,11 @@ msgstr "AllContiguous - House"
 msgid "house-contiguous long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Contiguity</p><p>Every part of a district must be reachable from every"
-" other part without crossing the district's borders. All districts "
-"within a plan must be contiguous. Water contiguity is permitted given "
-"Virginia's extensive coastal region. 'Point contiguity' or 'touch-"
-"point contiguity' where two sections of a district are connected at a "
-"single point is not permitted.</p>"
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:995
 msgid "house-major-minor short label"
@@ -2442,8 +2428,8 @@ msgstr "Equipopulation - Senate"
 msgid "senate-equipop long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Equipopulation:</p><p>The population of each House of Delegates "
-"district must be 200,026 +/- 5%.</p>"
+"Equipopulation:</p><p>The population of each House of Delegates district "
+"must be 200,026 +/- 5%.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1011
 msgid "senate-contiguous short label"
@@ -2457,12 +2443,11 @@ msgstr "AllContiguous - Senate"
 msgid "senate-contiguous long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Contiguity</p><p>Every part of a district must be reachable from every"
-" other part without crossing the district's borders. All districts "
-"within a plan must be contiguous. Water contiguity is permitted given "
-"Virginia's extensive coastal region. 'Point contiguity' or 'touch-"
-"point contiguity' where two sections of a district are connected at a "
-"single point is not permitted.</p>"
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1020
 msgid "senate-assigned short label"
@@ -2519,4 +2504,16 @@ msgstr "Community Mapping"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:931
 msgid "community_sidebar_comments long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio short label"
+msgstr "Convex Hull Ratio"
+
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio label"
+msgstr "Convex Hull Ratio"
+
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio long description"
 msgstr ""

--- a/django/publicmapping/locale/ja/LC_MESSAGES/xmlconfig.po
+++ b/django/publicmapping/locale/ja/LC_MESSAGES/xmlconfig.po
@@ -7,10 +7,10 @@ msgstr ""
 "PO-Revision-Date: 2012-01-14 01:47+0000\n"
 "Last-Translator: admin <dzwarg+admin@azavea.com>\n"
 "Language-Team: admin <dzwarg+admin@azavea.com>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:10
 msgid "congress short label"
@@ -122,27 +122,27 @@ msgstr "Communities"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:63
 msgid "dc_vtd short label"
-msgstr "vtd"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:63
 msgid "dc_vtd label"
-msgstr "VTD"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:63
 msgid "dc_vtd long description"
-msgstr "Voter Tabulation Districts"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:62
 msgid "dc_block short label"
-msgstr "block"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:62
 msgid "dc_block label"
-msgstr "Block"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:62
 msgid "dc_block long description"
-msgstr "Census Blocks"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1142
 msgid "county short label"
@@ -150,47 +150,47 @@ msgstr "county"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1142
 msgid "county label"
-msgstr "County"
+msgstr "county"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1142
 msgid "county long description"
-msgstr "Counties"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:37
 msgid "va_block short label"
-msgstr "block"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:37
 msgid "va_block label"
-msgstr "Block"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:37
 msgid "va_block long description"
-msgstr "Census Blocks"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:38
 msgid "va_vtd short label"
-msgstr "vtd"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:38
 msgid "va_vtd label"
-msgstr "VTD"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:38
 msgid "va_vtd long description"
-msgstr "Voter Tabulation Districts"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:39
 msgid "va_county short label"
-msgstr "county"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:39
 msgid "va_county label"
-msgstr "County"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:39
 msgid "va_county long description"
-msgstr "Counties"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1088
 msgid "vtd short label"
@@ -198,11 +198,11 @@ msgstr "vtd"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1088
 msgid "vtd label"
-msgstr "VTD"
+msgstr "vtd"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1088
 msgid "vtd long description"
-msgstr "Voter Tabulation Districts"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1027
 msgid "block short label"
@@ -210,11 +210,11 @@ msgstr "block"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1027
 msgid "block label"
-msgstr "Block"
+msgstr "block"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1027
 msgid "block long description"
-msgstr "Census Blocks"
+msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:853
 msgid "congress_leader_all short label"
@@ -482,8 +482,7 @@ msgstr "Count Districts"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:342
 msgid "a_congress_plan_count_districts long description"
 msgstr ""
-"The number of districts in a Congressional redistricting plan must be "
-"11."
+"The number of districts in a Congressional redistricting plan must be 11."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:373
 msgid "a_congress_plan_equipopulation_summary short label"
@@ -496,8 +495,7 @@ msgstr "Target Pop. (727,366)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:373
 msgid "a_congress_plan_equipopulation_summary long description"
 msgstr ""
-"The population of each Congressional district must be 727,366 +/- "
-"0.5%."
+"The population of each Congressional district must be 727,366 +/- 0.5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:363
 msgid "a_congress_plan_equipopulation_validation short label"
@@ -510,8 +508,7 @@ msgstr "Target Pop. (727,366)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:363
 msgid "a_congress_plan_equipopulation_validation long description"
 msgstr ""
-"The population of each Congressional district must be 727,366 +/- "
-"0.5%."
+"The population of each Congressional district must be 727,366 +/- 0.5%."
 
 msgid "a_dc_area_council_plan_equipopulation_summary short label"
 msgstr "人口目標数 (292,843)"
@@ -551,8 +548,8 @@ msgstr "Count Districts"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:349
 msgid "a_house_plan_count_districts long description"
 msgstr ""
-"The number of districts in a House of Delegates redistricting plan "
-"must be 100."
+"The number of districts in a House of Delegates redistricting plan must be "
+"100."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:393
 msgid "a_house_plan_equipopulation_summary short label"
@@ -565,8 +562,7 @@ msgstr "Target Pop. (80,010)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:393
 msgid "a_house_plan_equipopulation_summary long description"
 msgstr ""
-"The population of each House of Delegates district must be 80,010 +/- "
-"5%."
+"The population of each House of Delegates district must be 80,010 +/- 5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:383
 msgid "a_house_plan_equipopulation_validation short label"
@@ -579,8 +575,7 @@ msgstr "Target Pop. (80,010)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:383
 msgid "a_house_plan_equipopulation_validation long description"
 msgstr ""
-"The population of each House of Delegates district must be 80,010 +/- "
-"5%."
+"The population of each House of Delegates district must be 80,010 +/- 5%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:321
 msgid "a_house_population short label"
@@ -605,8 +600,7 @@ msgstr "Count Districts"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:356
 msgid "a_senate_plan_count_districts long description"
 msgstr ""
-"The number of districts in a State Senate redistricting plan must be "
-"100."
+"The number of districts in a State Senate redistricting plan must be 100."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:413
 msgid "a_senate_plan_equipopulation_summary short label"
@@ -904,12 +898,12 @@ msgstr "All Contiguous"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:429
 msgid "plan_all_contiguous long description"
 msgstr ""
-"Contiguity means that every part of a district must be reachable from "
-"every other part without crossing the district's borders. All "
-"districts within a plan must be contiguous. Water contiguity is "
-"permitted given Virginia's extensive coastal region. 'Point "
-"contiguity' or 'touch-point contiguity' where two sections of a "
-"district are connected at a single point is not permitted."
+"Contiguity means that every part of a district must be reachable from every "
+"other part without crossing the district's borders. All districts within a "
+"plan must be contiguous. Water contiguity is permitted given Virginia's "
+"extensive coastal region. 'Point contiguity' or 'touch-point contiguity' "
+"where two sections of a district are connected at a single point is not "
+"permitted."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:243
 msgid "plan_all_equipop short label"
@@ -946,14 +940,13 @@ msgstr "Competitiveness"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:435
 msgid "plan_competitiveness long description"
 msgstr ""
-"Each plan's overall political competitiveness is determined by "
-"averaging each district.s 'partisan differential'.  The partisan "
-"differential of each district is calculated by subtracting the "
-"Democratic 'partisan index' from the Republican 'partisan "
-"index'.<br/><br/>'Heavily' competitive districts are districts with "
-"partisan differentials of less than or equal to 5%. 'Generally' "
-"competitive districts are districts with partisan differentials of "
-"greater than 5% but less than 10%."
+"Each plan's overall political competitiveness is determined by averaging "
+"each district.s 'partisan differential'.  The partisan differential of each "
+"district is calculated by subtracting the Democratic 'partisan index' from "
+"the Republican 'partisan index'.<br/><br/>'Heavily' competitive districts "
+"are districts with partisan differentials of less than or equal to 5%. "
+"'Generally' competitive districts are districts with partisan differentials "
+"of greater than 5% but less than 10%."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:285
 msgid "plan_contiguous short label"
@@ -990,8 +983,8 @@ msgstr "Equal Population"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:443
 msgid "plan_equivalence long description"
 msgstr ""
-"The Equipopulation score is the difference between the district with "
-"the highest population and the district with the lowest population."
+"The Equipopulation score is the difference between the district with the "
+"highest population and the district with the lowest population."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:260
 msgid "plan_hispvap_thresh short label"
@@ -1016,11 +1009,11 @@ msgstr "Majority Minority District"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:486
 msgid "plan_majority_minority long description"
 msgstr ""
-"Compliance with the Voting Rights Act will be assumed if maps include "
-"a minority-majority district in any area where a minority group is (as"
-" described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) "
-"'sufficiently large and geographically compact to constitute a "
-"majority in a single-member district'."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 msgid "plan_majority_minority_blk short label"
 msgstr "黒人投票年齢人口多数(>50%)"
@@ -1044,11 +1037,11 @@ msgstr "Black VAP Majority (>50%)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:450
 msgid "plan_majority_minority_blk_congress long description"
 msgstr ""
-"Compliance with the Voting Rights Act will be assumed if maps include "
-"a minority-majority district in any area where a minority group is (as"
-" described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) "
-"'sufficiently large and geographically compact to constitute a "
-"majority in a single-member district'."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:459
 msgid "plan_majority_minority_blk_house short label"
@@ -1061,11 +1054,11 @@ msgstr "Black VAP Majority (>50%)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:459
 msgid "plan_majority_minority_blk_house long description"
 msgstr ""
-"Compliance with the Voting Rights Act will be assumed if maps include "
-"a minority-majority district in any area where a minority group is (as"
-" described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) "
-"'sufficiently large and geographically compact to constitute a "
-"majority in a single-member district'."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:468
 msgid "plan_majority_minority_blk_senate short label"
@@ -1078,11 +1071,11 @@ msgstr "Black VAP Majority (>50%)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:468
 msgid "plan_majority_minority_blk_senate long description"
 msgstr ""
-"Compliance with the Voting Rights Act will be assumed if maps include "
-"a minority-majority district in any area where a minority group is (as"
-" described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) "
-"'sufficiently large and geographically compact to constitute a "
-"majority in a single-member district'."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:477
 msgid "plan_majority_minority_hisp short label"
@@ -1095,11 +1088,11 @@ msgstr "Hisp. VAP Majority (>50%)"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:477
 msgid "plan_majority_minority_hisp long description"
 msgstr ""
-"Compliance with the Voting Rights Act will be assumed if maps include "
-"a minority-majority district in any area where a minority group is (as"
-" described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) "
-"'sufficiently large and geographically compact to constitute a "
-"majority in a single-member district'."
+"Compliance with the Voting Rights Act will be assumed if maps include a "
+"minority-majority district in any area where a minority group is (as "
+"described in Thornburg V. Gingles, 478 U.S. 30, 49 (1986)) 'sufficiently "
+"large and geographically compact to constitute a majority in a single-member"
+" district'."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:278
 msgid "plan_major_minor short label"
@@ -1136,10 +1129,10 @@ msgstr "Representational Fairness"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:496
 msgid "plan_repfairness long description"
 msgstr ""
-"Representational fairness is increased when the percentage of "
-"districts a party would likely win (based upon the 'partisan index' "
-"used to determine Competitiveness) closely mirrors that party.s "
-"percentage of the statewide vote."
+"Representational fairness is increased when the percentage of districts a "
+"party would likely win (based upon the 'partisan index' used to determine "
+"Competitiveness) closely mirrors that party.s percentage of the statewide "
+"vote."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:505
 msgid "plan_schwartzberg short label"
@@ -1152,10 +1145,9 @@ msgstr "Average Compactness"
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:505
 msgid "plan_schwartzberg long description"
 msgstr ""
-"The competition is using the 'Inverse Schwartzberg' compactness "
-"measure. This measure is a ratio of the circumference of the circle "
-"whose area is equal to the area of the district to the perimeter of "
-"the district."
+"The competition is using the 'Inverse Schwartzberg' compactness measure. "
+"This measure is a ratio of the circumference of the circle whose area is "
+"equal to the area of the district to the perimeter of the district."
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:239
 msgid "plan_sum_equipop short label"
@@ -2243,8 +2235,8 @@ msgstr "Equipopulation - Congress"
 msgid "congress-equipop long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Equipopulation:</p><p>The population of each Congressional district "
-"must be 727,366 +/- 0.5%.</p>"
+"Equipopulation:</p><p>The population of each Congressional district must be "
+"727,366 +/- 0.5%.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:973
 msgid "congress-contiguous short label"
@@ -2258,12 +2250,11 @@ msgstr "AllContiguous - Congress"
 msgid "congress-contiguous long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Contiguity</p><p>Every part of a district must be reachable from every"
-" other part without crossing the district's borders. All districts "
-"within a plan must be contiguous. Water contiguity is permitted given "
-"Virginia's extensive coastal region. 'Point contiguity' or 'touch-"
-"point contiguity' where two sections of a district are connected at a "
-"single point is not permitted.</p>"
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:976
 msgid "congress-major-minor short label"
@@ -2313,8 +2304,8 @@ msgstr "Equipopulation - House"
 msgid "house-equipop long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Equipopulation:</p><p>The population of each House of Delegates "
-"district must be 80,010 +/- 5%.</p>"
+"Equipopulation:</p><p>The population of each House of Delegates district "
+"must be 80,010 +/- 5%.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:992
 msgid "house-contiguous short label"
@@ -2328,12 +2319,11 @@ msgstr "AllContiguous - House"
 msgid "house-contiguous long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Contiguity</p><p>Every part of a district must be reachable from every"
-" other part without crossing the district's borders. All districts "
-"within a plan must be contiguous. Water contiguity is permitted given "
-"Virginia's extensive coastal region. 'Point contiguity' or 'touch-"
-"point contiguity' where two sections of a district are connected at a "
-"single point is not permitted.</p>"
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:995
 msgid "house-major-minor short label"
@@ -2407,8 +2397,8 @@ msgstr "Equipopulation - Senate"
 msgid "senate-equipop long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Equipopulation:</p><p>The population of each House of Delegates "
-"district must be 200,026 +/- 5%.</p>"
+"Equipopulation:</p><p>The population of each House of Delegates district "
+"must be 200,026 +/- 5%.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1011
 msgid "senate-contiguous short label"
@@ -2422,12 +2412,11 @@ msgstr "AllContiguous - Senate"
 msgid "senate-contiguous long description"
 msgstr ""
 "<p>Your plan does not meet the competition criteria for "
-"Contiguity</p><p>Every part of a district must be reachable from every"
-" other part without crossing the district's borders. All districts "
-"within a plan must be contiguous. Water contiguity is permitted given "
-"Virginia's extensive coastal region. 'Point contiguity' or 'touch-"
-"point contiguity' where two sections of a district are connected at a "
-"single point is not permitted.</p>"
+"Contiguity</p><p>Every part of a district must be reachable from every other"
+" part without crossing the district's borders. All districts within a plan "
+"must be contiguous. Water contiguity is permitted given Virginia's extensive"
+" coastal region. 'Point contiguity' or 'touch-point contiguity' where two "
+"sections of a district are connected at a single point is not permitted.</p>"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:1020
 msgid "senate-assigned short label"
@@ -2452,11 +2441,11 @@ msgstr "コロンビア特別区首都圏"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:926
 msgid "community_sidebar_demo short label"
-msgstr "人口統計"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:926
 msgid "community_sidebar_demo label"
-msgstr "人口統計"
+msgstr "Demographics"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:926
 msgid "community_sidebar_demo long description"
@@ -2464,12 +2453,36 @@ msgstr ""
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:931
 msgid "community_sidebar_comments short label"
-msgstr "コミュニティ・マップ"
+msgstr "Community Mapping"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:931
 msgid "community_sidebar_comments label"
-msgstr "コミュニティ・マップ"
+msgstr "Community Mapping"
 
 #: /projects/PublicMapping/DistrictBuilder/docs/config.xml:931
 msgid "community_sidebar_comments long description"
+msgstr ""
+
+#: /usr/src/app/config/config.xml:45
+msgid "dc short label"
+msgstr "dc"
+
+#: /usr/src/app/config/config.xml:45
+msgid "dc label"
+msgstr "DC Metro"
+
+#: /usr/src/app/config/config.xml:45
+msgid "dc long description"
+msgstr "The District of Columbia Metropolitan Area"
+
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio short label"
+msgstr "Convex Hull Ratio"
+
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio label"
+msgstr "Convex Hull Ratio"
+
+#: /usr/src/app/config/config.xml:196
+msgid "district_convexhullratio long description"
 msgstr ""

--- a/django/publicmapping/redistricting/config.py
+++ b/django/publicmapping/redistricting/config.py
@@ -136,7 +136,11 @@ class ConfigImporter:
         Save all modified po files.
         """
         for locale in self.poutils:
-            self.poutils[locale].save()
+            # TODO: these are coming from somewhere in the setup process.
+            # It's not clear where, but there are too many. Remove this
+            # check and the ENABLED_LANGUAGES setting when that's resolved.
+            if locale in settings.ENABLED_LANGUAGES:
+                self.poutils[locale].save()
 
     def import_superuser(self, force):
         """
@@ -1606,13 +1610,16 @@ class PoUtils:
                 'Report-Msgid-Bugs-To': 'districtbuilder-dev@googlegroups.com',
                 'POT-Creation-Date': now.strftime('%Y-%m-%d %H:%M%z'),
                 'PO-Revision-Date': now.strftime('%Y-%m-%d %H:%M%z'),
-                'Last-Translator': '%s <%s>' % (settings.ADMINS[0][0], settings.ADMINS[0][1]),
-                'Language-Team': '%s <%s>' % (settings.ADMINS[0][0], settings.ADMINS[0][1]),
                 'Language': locale,
                 'MIME-Version': '1.0',
                 'Content-Type': 'text/plain; charset=UTF-8',
                 'Content-Transfer-Encoding': '8bit'
             }
+            if settings.ADMINS:
+                self.pofile.metadata.update({
+                    'Last-Translator': '%s <%s>' % (settings.ADMINS[0][0], settings.ADMINS[0][1]),
+                    'Language-Team': '%s <%s>' % (settings.ADMINS[0][0], settings.ADMINS[0][1]),
+                })
 
     def add_or_update(self, msgid='', msgstr='', occurs=[]):
         """

--- a/django/publicmapping/redistricting/config.py
+++ b/django/publicmapping/redistricting/config.py
@@ -22,7 +22,7 @@ License:
     See the License for the specific language governing permissions and
     limitations under the License.
 
-Author: 
+Author:
     Andrew Jennings, David Zwarg, Kenny Shepard
 """
 
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 def check_and_update(a_model, unique_id_field='name', overwrite=False, **kwargs):
     """
-    Check whether an object exists with the given name in the database. If the 
+    Check whether an object exists with the given name in the database. If the
     object exists and "overwrite" is True, overwrite the object.  If "overwrite"
     is false, don't overwrite.  If the object doesn't exist, it is always created.
 
@@ -51,8 +51,8 @@ def check_and_update(a_model, unique_id_field='name', overwrite=False, **kwargs)
     @param unique_id_field: The field name that is unique.
     @keyword overwrite: Should the new object be overwritten?
     @returns: tuple - the object in the DB after any changes are made,
-        whether the object had to be created, 
-        whether the given attributes were consistent with what was in the database, 
+        whether the object had to be created,
+        whether the given attributes were consistent with what was in the database,
         a message to return indicating any changes.
     """
     name = kwargs[unique_id_field]
@@ -324,7 +324,7 @@ class ConfigImporter:
                 'is_displayed': subj.get('displayed')=='true',
                 'sort_key': subj.get('sortkey')
             }
-                
+
             obj, created, changed, message = check_and_update(Subject, overwrite=force, **attributes)
 
             for locale in [l[0] for l in settings.LANGUAGES]:
@@ -393,9 +393,9 @@ class ConfigImporter:
                 'sort_key': geolevel.get('sort_key'),
                 'tolerance': geolevel.get('tolerance')
             }
-            
+
             glvl, created, changed, message = check_and_update(Geolevel, overwrite=force, **attributes)
-    
+
             for locale in [l[0] for l in settings.LANGUAGES]:
                 po = self.poutils[locale]
                 po.add_or_update(
@@ -482,7 +482,7 @@ class ConfigImporter:
             lbodies = self.store.filter_regional_legislative_bodies(region)
             for lbody in lbodies:
                 legislative_body = LegislativeBody.objects.get(name=lbody.get('ref')[:256])
-                
+
                 # Add a mapping for the subjects in this GL/LB combo.
                 sconfig = self.store.get_legislative_body_default_subject(lbody)
                 if not sconfig.get('aliasfor') is None:
@@ -500,7 +500,7 @@ class ConfigImporter:
                     obj, created = LegislativeLevel.objects.get_or_create(
                         legislative_body=body,
                         geolevel=geolevel,
-                        subject=subject, 
+                        subject=subject,
                         parent=parent)
 
                     if created:
@@ -527,7 +527,7 @@ class ConfigImporter:
         result = True
         if not self.store.has_scoring():
             logger.debug('Scoring not configured')
-        
+
         admin = User.objects.filter(is_superuser=True)
         if admin.count() == 0:
             logger.debug('There was no superuser installed; ScoreDisplays need to be assigned ownership to a superuser.')
@@ -538,7 +538,7 @@ class ConfigImporter:
         # Import score displays.
         for sd in self.store.filter_scoredisplays():
             lb = LegislativeBody.objects.get(name=sd.get('legislativebodyref'))
-             
+
             sd_obj, created = ScoreDisplay.objects.get_or_create(
                 name=sd.get('id')[:50],
                 title=sd.get('title')[:50],
@@ -584,7 +584,7 @@ class ConfigImporter:
                 is_ascending = sp.get('is_ascending')
                 if is_ascending is None:
                     is_ascending = True
-                
+
                 ascending = sp.get('is_ascending')
                 sp_obj, created = ScorePanel.objects.get_or_create(
                     type=pnltype,
@@ -592,7 +592,7 @@ class ConfigImporter:
                     name=name,
                     template=template,
                     cssclass=cssclass,
-                    is_ascending=(ascending is None or ascending=='true'), 
+                    is_ascending=(ascending is None or ascending=='true'),
                 )
 
                 if created:
@@ -790,8 +790,8 @@ class ConfigImporter:
                     logger.info('subject ScoreArgument "%s" value UPDATED', name)
                 else:
                     logger.info('Didn\'t change ScoreArgument %s; attribute(s) "value" differ(s) from database configuration.\n\tWARNING: Sync your config file to your app configuration or use the -f switch with setup to force changes', name)
-                    
-        
+
+
         # Import score arguments for this score function
         for scorearg in self.store.filter_function_score_arguments(node):
             argfn = self.store.get_score_function(scorearg.get('ref'))
@@ -833,7 +833,7 @@ class ConfigImporter:
         """
         # Remove previous contiguity overrides
         ContiguityOverride.objects.all().delete()
-            
+
         if not self.store.has_contiguity_overrides():
             logger.debug('ContiguityOverrides not configured')
 
@@ -852,8 +852,8 @@ class ConfigImporter:
             connect_to_geounit = temp[0]
 
             co_obj, created = ContiguityOverride.objects.get_or_create(
-                override_geounit=override_geounit, 
-                connect_to_geounit=connect_to_geounit 
+                override_geounit=override_geounit,
+                connect_to_geounit=connect_to_geounit
                 )
 
             if created:
@@ -909,13 +909,13 @@ class SpatialUtils:
             raise Exception()
 
         if self.host == '':
-            self.host = 'localhost'
+            self.host = 'geoserver.internal.districtbuilder.com'
 
         auth = 'Basic %s' % base64.b64encode(user_pass)
         self.headers = {
                 'default': {
-                'Authorization': auth, 
-                'Content-Type': 'application/json', 
+                'Authorization': auth,
+                'Content-Type': 'application/json',
                 'Accepts':'application/json'
             },
             'sld': {
@@ -930,13 +930,13 @@ class SpatialUtils:
         """
         Remove any configured items in geoserver for the namespace.
 
-        This configuration step prevents conflicts in geowebcache 
-        when the datastore and featuretype is reconfigured without 
+        This configuration step prevents conflicts in geowebcache
+        when the datastore and featuretype is reconfigured without
         discarding the old featuretype.
 
         @returns: A flag indicating if the configuration was purged successfully.
         """
-        # get the workspace 
+        # get the workspace
         ws_cfg = self._read_config('/geoserver/rest/workspaces/%s.json' % self.ns, 'Could not get workspace %s.' % self.ns)
         if ws_cfg is None:
             logger.debug("%s configuration could not be fetched.", self.ns)
@@ -960,7 +960,7 @@ class SpatialUtils:
             logger.debug("Data store '%s' feature type configuration could not be fetched.", wsds_cfg['dataStores']['dataStore'][0]['name'])
             return False
 
-        if not 'featureType' in fts_cfg['featureTypes']: 
+        if not 'featureType' in fts_cfg['featureTypes']:
             fts_cfg['featureTypes'] = { 'featureType':[] }
 
         for ft_cfg in fts_cfg['featureTypes']['featureType']:
@@ -1008,7 +1008,7 @@ class SpatialUtils:
     def configure_geoserver(self):
         """
         Configure all the components in Geoserver. This method configures the
-        geoserver workspace, datastore, feature types, and styles. All 
+        geoserver workspace, datastore, feature types, and styles. All
         configuration steps get processed through the REST config.
 
         @returns: A flag indicating if geoserver was configured correctly.
@@ -1026,12 +1026,12 @@ class SpatialUtils:
             logger.debug('Created namespace "%s"' % self.ns)
         else:
             logger.warn('Could not create Namespace')
-            return
+            return False
 
         # Create our DataStore
         if self.store is None:
             logger.warning('Geoserver cannot be fully configured without a stored config.')
-            return
+            return False
 
         dbconfig = self.store.get_database()
 
@@ -1058,7 +1058,7 @@ class SpatialUtils:
             logger.debug('Created datastore "%s"' % data_store_name)
         else:
             logger.warn('Could not create Datastore')
-            return
+            return False
 
         # Create the feature types and their styles
 
@@ -1071,7 +1071,7 @@ class SpatialUtils:
             if geolevel.legislativelevel_set.all().count() == 0:
                 # Skip 'abstract' geolevels if regions are configured
                 continue
-            
+
             if self.create_featuretype('simple_%s' % geolevel.name):
                 logger.debug('Created "simple_%s" feature type' % geolevel.name)
             else:
@@ -1082,7 +1082,7 @@ class SpatialUtils:
             else:
                 logger.warn('Colud not create "simple_district_%s" feature type' % geolevel.name)
 
-            all_subjects = Subject.objects.all().order_by('sort_key') 
+            all_subjects = Subject.objects.all().order_by('sort_key')
             if all_subjects.count() > 0:
                 subject = all_subjects[0]
 
@@ -1144,7 +1144,7 @@ class SpatialUtils:
                     logger.debug('Assigned style for "%s"' % featuretype_name)
                 else:
                     logger.warn('Could not assign style for "%s"' % featuretype_name)
-            
+
             for subject in all_subjects:
                 featuretype_name = get_featuretype_name(geolevel.name, subject.name)
 
@@ -1174,7 +1174,7 @@ class SpatialUtils:
                     logger.debug('Assigned "%s" style' % featuretype_name)
                 else:
                     logger.warn('Could not assign "%s" style' % featuretype_name)
-            
+
         # map all the legislative body / geolevels combos
         ngeolevels_map = []
         for lbody in LegislativeBody.objects.all():
@@ -1210,11 +1210,11 @@ class SpatialUtils:
                 interval_bnd2 = float(interval.xpath('Argument[@name="bound2"]')[0].get('value'))
 
                 intervals = [
-                    (interval_avg + interval_avg * interval_bnd2, None, 
+                    (interval_avg + interval_avg * interval_bnd2, None,
                         _('Far Over Target'), {'fill':'#ebb95e', 'fill-opacity':'0.3'}),
-                    (interval_avg + interval_avg * interval_bnd1, interval_avg + interval_avg * interval_bnd2, 
+                    (interval_avg + interval_avg * interval_bnd1, interval_avg + interval_avg * interval_bnd2,
                         _('Over Target'), {'fill':'#ead3a7', 'fill-opacity':'0.3'}),
-                    (interval_avg - interval_avg * interval_bnd1, interval_avg + interval_avg * interval_bnd1, 
+                    (interval_avg - interval_avg * interval_bnd1, interval_avg + interval_avg * interval_bnd1,
                         _('Meets Target'), {'fill':'#eeeeee', 'fill-opacity':'0.1'}),
                     (interval_avg - interval_avg * interval_bnd2, interval_avg - interval_avg * interval_bnd1,
                         _('Under Target'), {'fill':'#a2d5d0', 'fill-opacity':'0.3'}),
@@ -1277,7 +1277,7 @@ class SpatialUtils:
         return self._check_spatial_resource(feature_type_url, feature_type_name, feature_type_obj)
 
     def _check_spatial_resource(self, url, name, dictionary, update=False):
-        """ 
+        """
         This method will check geoserver for the existence of an object.
         It will create the object if it doesn't exist.
 
@@ -1292,7 +1292,7 @@ class SpatialUtils:
             if update:
                 if not self._rest_config( 'PUT', url, data=json.dumps(dictionary)):
                     return False
-                
+
         else:
             if not self._rest_config( 'POST', url, data=json.dumps(dictionary)):
                 return False
@@ -1435,7 +1435,7 @@ class SpatialUtils:
             us_title = subject.get_short_label()
         else:
             us_title = layername
-            
+
         qset = qset.annotate(Avg('characteristic__number'))
 
         doc = generator.as_quantiles(qset, 'characteristic__number__avg', nclasses, propertyname='number',
@@ -1456,16 +1456,16 @@ class SpatialUtils:
             # remove any fill if subject is missing
             fill = doc._node.xpath('//sld:Fill', namespaces=doc._nsmap)[0]
             fill.getparent().remove(fill)
-        
+
             if layername:
                 # set the name of the layer
                 name = doc._node.xpath('//sld:Name', namespaces=doc._nsmap)[0]
                 name.text = layername
-        
+
                 # set the title of the user style
                 name = doc._node.xpath('//sld:UserStyle/sld:Title', namespaces=doc._nsmap)[0]
                 name.text = geolevel.get_long_description()
-        
+
                 # set the title of the rule
                 name = doc._node.xpath('//sld:Rule/sld:Title', namespaces=doc._nsmap)[0]
                 name.text = _('Boundary')
@@ -1495,7 +1495,7 @@ class SpatialUtils:
         @returns: True if the named style was configured properly
         """
         # Configure the named style
-        return self._rest_config( 'PUT', '/geoserver/rest/styles/%s:%s' % (self.ns, featuretype,), 
+        return self._rest_config( 'PUT', '/geoserver/rest/styles/%s:%s' % (self.ns, featuretype,),
             data=sld_content, headers=self.headers['sld'])
 
 
@@ -1519,7 +1519,7 @@ class SpatialUtils:
 
         if self._rest_config( 'PUT', '/geoserver/rest/layers/%s:%s' % (self.ns, featuretype,), data=json.dumps(layer)):
             return True
-        
+
         return False
 
 
@@ -1563,7 +1563,7 @@ class SpatialUtils:
             # If this geolevel doesn't exist in this region, try the next region
             if llevel is None:
                 continue
-       
+
             # Get the parent node
             parent = llevel.getparent()
             while parent.getparent() is not None and parent.getparent().tag != 'GeoLevels':

--- a/django/publicmapping/redistricting/management/commands/database_i18n.py
+++ b/django/publicmapping/redistricting/management/commands/database_i18n.py
@@ -22,7 +22,7 @@ License:
     See the License for the specific language governing permissions and
     limitations under the License.
 
-Author: 
+Author:
     Andrew Jennings, David Zwarg
 """
 
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     """
-    This command migrates all database configured strings into a set of 
+    This command migrates all database configured strings into a set of
     message files in the 'xmlconfig' domain.
     """
     args = None
@@ -72,7 +72,7 @@ class Command(BaseCommand):
         # Use the specified locale, or if none are provided, use all defined in settings
         locale = options.get("locale")
         locales = [locale] if locale else [l[0] for l in settings.LANGUAGES]
-        
+
         # Make messages for each available locale
         for locale in locales:
             logger.info('Processing locale %(locale)s', {'locale':locale})

--- a/django/publicmapping/redistricting/management/commands/makelanguagefiles.py
+++ b/django/publicmapping/redistricting/management/commands/makelanguagefiles.py
@@ -36,12 +36,12 @@ class Command(BaseCommand):
     """
     args = None
     help = 'Create and compile language message files'
-    option_list = BaseCommand.option_list + (
-        make_option('-t', '--templates', dest="templates", action="store_true", help="Create template message files.", default=False),
-        make_option('-j', '--javascript', dest="javascript", action="store_true", help="Create javascript message files.", default=False),
-        make_option('-c', '--compile', dest="compile", action="store_true", help="Compile message files.", default=False),
-        make_option('-l', '--locale', dest='locale', default=None, action='store', help='Specify a locale.'),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('-t', '--templates', dest="templates", action="store_true", help="Create template message files.", default=False),
+        parser.add_argument('-j', '--javascript', dest="javascript", action="store_true", help="Create javascript message files.", default=False),
+        parser.add_argument('-c', '--compile', dest="compile", action="store_true", help="Compile message files.", default=False),
+        parser.add_argument('-l', '--locale', dest='locale', default=None, action='store', help='Specify a locale.')
 
     def handle(self, *args, **options):
         """
@@ -52,25 +52,27 @@ class Command(BaseCommand):
 
         # Use the specified locale, or if none are provided, use all defined in settings
         locale = options.get("locale")
-        locales = [locale] if locale else [l[0] for l in settings.LANGUAGES]
-        
+        locales = [locale] if locale else [
+            [l[0]] for l in settings.LANGUAGES if l[0] in settings.ENABLED_LANGUAGES
+        ]
+
         # Make messages for each available locale
         for locale in locales:
             # Make messages for templates (.html, .txt, .email)
             if everything or options.get("templates"):
-                management.call_command('makemessages', 
-                    locale=locale, 
-                    extensions=['html','txt','email'], 
+                management.call_command('makemessages',
+                    locale=locale,
+                    extensions=['html','txt','email'],
                     interactive=False,
                     verbosity=options.get('verbosity'),
                     ignore_patterns=[ 'static-media/jquery/*.*']
                 )
-        
+
             # Make messages for javascript
             if everything or options.get("javascript"):
-                management.call_command('makemessages', 
-                    locale=locale, 
-                    domain='djangojs', 
+                management.call_command('makemessages',
+                    locale=locale,
+                    domain='djangojs',
                     interactive=False,
                     verbosity=options.get('verbosity'),
                     ignore_patterns=[ 'static-media*' ]
@@ -78,7 +80,7 @@ class Command(BaseCommand):
 
             # Compile message file
             if everything or options.get("compile"):
-                management.call_command('compilemessages', 
+                management.call_command('compilemessages',
                     locale=locale,
                     interactive=False,
                     verbosity=options.get('verbosity')

--- a/django/publicmapping/redistricting/management/commands/setup.py
+++ b/django/publicmapping/redistricting/management/commands/setup.py
@@ -198,7 +198,6 @@ file and try again.
             all_ok = False
             logger.info('ERROR importing geolevels.')
             logger.debug(traceback.format_exc())
-            raise
 
 
         # Do this once after processing the geolevels

--- a/django/publicmapping/redistricting/management/commands/setup.py
+++ b/django/publicmapping/redistricting/management/commands/setup.py
@@ -47,7 +47,7 @@ from xml.dom import minidom
 import redistricting
 from redistricting.models import *
 from redistricting.tasks import *
-from redistricting.config import *
+from redistricting.config import ConfigImporter
 import traceback, logging
 
 from redisutils import key_gen
@@ -55,6 +55,7 @@ from django.db.models import Q
 import subprocess
 
 logger = logging.getLogger()
+logger.addHandler(logging.StreamHandler())
 
 
 class Command(BaseCommand):
@@ -63,42 +64,35 @@ class Command(BaseCommand):
     """
     args = '<config>'
     help = 'Sets up DistrictBuilder based on the main XML configuration.'
-    option_list = BaseCommand.option_list + (
-        make_option('-c', '--config', dest="config",
-            help="Use configuration file CONFIG", metavar="CONFIG"),
-        make_option('-d', '--database', dest="database",
-            help="Generate the base data objects.", default=False,
-            action='store_true'),
-        make_option('-f', '--force', dest="force",
-            help="Force changes if config differs from database", default=False,
-            action='store_true'),
-        make_option('-g', '--geolevel', dest="geolevels",
-            action="append", help="Geolevels to import",
-            type='int'),
-        make_option('-n', '--nesting', dest="nesting",
-            action='append', help="Enforce nested geometries.",
-            type='int'),
-        make_option('-V', '--views', dest="views", default=False,
-            action="store_true", help="Create database views."),
-        make_option('-G', '--geoserver', dest="geoserver",
-            action="store_true", help="Create spatial layers in Geoserver.",
-            default=False),
-        make_option('-t', '--templates', dest="templates",
-            action="store_true", help="Create system templates based on district index files.", default=False),
-        make_option('-a', '--adjacency', dest="adjacency",
-                    help="Import adjacency data", default=False, action='store_true'),
-        make_option('-b', '--bard', dest="bard",
-            action='store_true', help="Create a BARD map based on the imported spatial data.", default=False),
-        make_option('-s', '--static', dest="static",
-            action='store_true', help="Collect and compress the static javascript and css files.", default=False),
-        make_option('-l', '--languages', dest="languages",
-            action='store_true', help="Create and compile a message file for each language defined.", default=False),
-        make_option('-B', '--bardtemplates', dest="bard_templates",
-            action='store_true', help="Create the BARD reporting templates.", default=False),
-    )
-
 
     force = False
+
+    def add_arguments(self, parser):
+        """Add arguments and options to the base command parser"""
+        parser.add_argument('config',
+            help="Use configuration file CONFIG", metavar="CONFIG"),
+        parser.add_argument('-f', '--force', dest="force",
+            help="Force changes if config differs from database", default=False,
+            action='store_true'),
+        parser.add_argument('-g', '--geolevel', dest="geolevels",
+            action="append", help="Geolevels to import",
+            type=int),
+        parser.add_argument('-n', '--nesting', dest="nesting",
+            action='append', help="Enforce nested geometries.",
+            type=int),
+        parser.add_argument('-V', '--views', dest="views", default=False,
+            action="store_true", help="Create database views."),
+        parser.add_argument('-G', '--geoserver', dest="geoserver",
+            action="store_true", help="Create spatial layers in Geoserver.",
+            default=False),
+        parser.add_argument('-t', '--templates', dest="templates",
+            action="store_true", help="Create system templates based on district index files.", default=False),
+        parser.add_argument('-a', '--adjacency', dest="adjacency",
+                    help="Import adjacency data", default=False, action='store_true'),
+        parser.add_argument('-s', '--static', dest="static",
+            action='store_true', help="Collect and compress the static javascript and css files.", default=False),
+        parser.add_argument('-l', '--languages', dest="languages",
+            action='store_true', help="Create and compile a message file for each language defined.", default=False)
 
     def setup_logging(self, verbosity):
         """
@@ -115,6 +109,7 @@ class Command(BaseCommand):
         Perform the command.
         """
         self.setup_logging(int(options.get('verbosity')))
+        force = options.get('force')
 
         translation.activate('en')
 
@@ -161,8 +156,6 @@ file and try again.
         if not success:
             sys.exit(1)
 
-        force = options.get('force')
-
         # When configuring, we want to keep track of any failures so we can
         # return the correct exit code.  Since False evaluates to a 0, we can
         # multiply values by all_ok so that a single False value means all_ok
@@ -191,13 +184,12 @@ file and try again.
                 geolevels = store.filter_geolevels()
 
                 for i,geolevel in enumerate(geolevels):
-                    if not optlevels is None:
-                        importme = len(optlevels) == 0
-                        importme = importme or (i in optlevels)
+                    if optlevels is not None:
+                        importme = len(optlevels) == 0 or (i in optlevels)
                         if importme:
                             self.import_geolevel(store, geolevel)
 
-                    if not nestlevels is None:
+                    if nestlevels is not None:
                         nestme = len(nestlevels) == 0
                         nestme = nestme or (i in nestlevels)
                         if nestme:
@@ -252,17 +244,6 @@ file and try again.
 
         if options.get("adjacency"):
             self.import_adjacency(store.data)
-
-        if options.get("bard_templates"):
-            try:
-                self.create_report_templates(store.data)
-            except:
-                logger.info('ERROR creating BARD template files.')
-                logger.debug(traceback.format_exc())
-                all_ok = False
-
-        if options.get("bard"):
-            all_ok = all_ok * self.build_bardmap(store.data)
 
         # For our return value, a 0 (False) means OK, any nonzero (i.e., True or 1)
         # means that  an error occurred - the opposite of the meaning of all_ok's bool
@@ -359,12 +340,14 @@ ERROR:
                     width = int(idpart.get('width'))
                     builtid = '%s%s' % (builtid, part.zfill(width))
             return builtid
+
         def get_shape_portable(shapefile, feature):
             field = shapefile.xpath('Fields/Field[@type="portable"]')[0]
             portable = feature.get(field.get('name'))
             if not (isinstance(portable, types.StringTypes)):
                 portable = '%d' % portable
             return portable
+
         def get_shape_name(shapefile, feature):
             field = shapefile.xpath('Fields/Field[@type="name"]')[0]
             strname = feature.get(field.get('name'))

--- a/django/publicmapping/redistricting/management/commands/setup.py
+++ b/django/publicmapping/redistricting/management/commands/setup.py
@@ -198,6 +198,7 @@ file and try again.
             all_ok = False
             logger.info('ERROR importing geolevels.')
             logger.debug(traceback.format_exc())
+            raise
 
 
         # Do this once after processing the geolevels
@@ -519,7 +520,8 @@ ERROR:
             try:
                 value = Decimal(str(feat.get(attr))).quantize(Decimal('000000.0000', 'ROUND_DOWN'))
             except:
-                logger.info('No attribute "%s" on feature %d' , attr, feat.fid)
+
+                # logger.info('No attribute "%s" on feature %d' , attr, feat.fid)
                 continue
             percentage = '0000.00000000'
             if obj.percentage_denominator:

--- a/django/publicmapping/redistricting/management/commands/setup.py
+++ b/django/publicmapping/redistricting/management/commands/setup.py
@@ -586,17 +586,17 @@ ERROR:
         Parameters:
             config - The XML configuration.
         """
-        admin = User.objects.filter(is_staff=True)
-        if admin.count() == 0:
+        admins = User.objects.filter(is_staff=True)
+        if admins.count() == 0:
             logger.info("Creating templates requires at least one admin user.")
             return
 
-        admin = admin[0]
+        admin = admins[0]
 
-        deflang = 'en'
+        default_language = 'en'
         try:
-            deflang = config.xpath('//Internationalization')[0].get('default')
-            activate(deflang)
+            default_language = config.xpath('//Internationalization')[0].get('default')
+            activate(default_language)
         except:
             pass
 
@@ -619,7 +619,7 @@ ERROR:
             fconfig = template.xpath('Blockfile')[0]
             path = fconfig.get('path')
 
-            DistrictIndexFile.index2plan( plan_name, legislative_body.id, path, owner=admin, template=True, purge=False, email=None, language=deflang)
+            DistrictIndexFile.index2plan( plan_name, legislative_body.id, path, owner=admin, template=True, purge=False, email=None, language=default_language)
 
             logger.debug('Created template plan "%s"', plan_name)
 

--- a/django/publicmapping/redistricting/models.py
+++ b/django/publicmapping/redistricting/models.py
@@ -1996,10 +1996,8 @@ class Plan(models.Model):
 
             self.version += 1
             self.save()
-            transaction.commit()
             return True, self.version
         except Exception as ex:
-            transaction.rollback()
             return False, -1
 
     def get_district_info(self, version=None):
@@ -3961,59 +3959,30 @@ def configure_views():
     visualizations. All parameters for creating the views are saved
     in the database at this point.
     """
-    cursor = connection.cursor()
-
-    sql = "CREATE OR REPLACE VIEW identify_geounit AS SELECT rg.id, rg.name, rgg.geolevel_id, rg.geom, rc.number, rc.percentage, rc.subject_id FROM redistricting_geounit rg JOIN redistricting_geounit_geolevel rgg ON rg.id = rgg.geounit_id JOIN redistricting_characteristic rc ON rg.id = rc.geounit_id;"
-    cursor.execute(sql)
-
-    logger.debug('Created identify_geounit view ...')
-
-    for geolevel in Geolevel.objects.all():
-        if geolevel.legislativelevel_set.all().count() == 0:
-            # Skip 'abstract' geolevels if regions are configured
-            continue
-
-        lbset = ','.join(map( lambda x:str(x.legislative_body_id), geolevel.legislativelevel_set.all()))
-        sql = "CREATE OR REPLACE VIEW simple_district_%s AS SELECT rd.id, rd.district_id, rd.plan_id, st_geometryn(rd.simple, %d) AS geom, rp.legislative_body_id FROM publicmapping.redistricting_district as rd JOIN publicmapping.redistricting_plan as rp ON rd.plan_id = rp.id WHERE rp.legislative_body_id IN (%s);" % (geolevel.name, geolevel.id, lbset)
+    with connection.cursor() as cursor:
+        sql = "CREATE OR REPLACE VIEW identify_geounit AS SELECT rg.id, rg.name, rgg.geolevel_id, rg.geom, rc.number, rc.percentage, rc.subject_id FROM redistricting_geounit rg JOIN redistricting_geounit_geolevel rgg ON rg.id = rgg.geounit_id JOIN redistricting_characteristic rc ON rg.id = rc.geounit_id;"
         cursor.execute(sql)
-        try:
-            transaction.commit()
-        except:
-            transaction.rollback()
-            logger.error('Failed to create simple_district_%s view',
-                geolevel.name)
-            logger.error(format_exc())
 
-        logger.debug('Created simple_district_%s view ...', geolevel.name)
+        logger.debug('Created identify_geounit view ...')
 
-        sql = "CREATE OR REPLACE VIEW simple_%s AS SELECT rg.id, rg.name, rgg.geolevel_id, rg.simple as geom FROM redistricting_geounit rg JOIN redistricting_geounit_geolevel rgg ON rg.id = rgg.geounit_id WHERE rgg.geolevel_id = %%(geolevel_id)s;" % geolevel.name
-        cursor.execute(sql, {'geolevel_id':geolevel.id})
-        try:
-            transaction.commit()
-        except:
-            transaction.rollback()
-            logger.error('Failed to create simple_%s view', geolevel.name)
-            logger.error(format_exc())
+        for geolevel in Geolevel.objects.all():
+            if geolevel.legislativelevel_set.all().count() == 0:
+                # Skip 'abstract' geolevels if regions are configured
+                continue
 
-        logger.debug('Created simple_%s view ...', geolevel.name)
+            lbset = ','.join(map( lambda x:str(x.legislative_body_id), geolevel.legislativelevel_set.all()))
+            sql = "CREATE OR REPLACE VIEW simple_district_%s AS SELECT rd.id, rd.district_id, rd.plan_id, st_geometryn(rd.simple, %d) AS geom, rp.legislative_body_id FROM redistricting_district as rd JOIN redistricting_plan as rp ON rd.plan_id = rp.id WHERE rp.legislative_body_id IN (%s);" % (geolevel.name, geolevel.id, lbset)
+            cursor.execute(sql)
+            logger.debug('Created simple_district_%s view ...', geolevel.name)
+
+            sql = "CREATE OR REPLACE VIEW simple_%s AS SELECT rg.id, rg.name, rgg.geolevel_id, rg.simple as geom FROM redistricting_geounit rg JOIN redistricting_geounit_geolevel rgg ON rg.id = rgg.geounit_id WHERE rgg.geolevel_id = %%(geolevel_id)s;" % geolevel.name
+            cursor.execute(sql, {'geolevel_id':geolevel.id})
+            logger.debug('Created simple_%s view ...', geolevel.name)
 
         for subject in Subject.objects.all():
             sql = "CREATE OR REPLACE VIEW %s AS SELECT rg.id, rg.name, rgg.geolevel_id, rg.geom, rc.number, rc.percentage FROM redistricting_geounit rg JOIN redistricting_geounit_geolevel rgg ON rg.id = rgg.geounit_id JOIN redistricting_characteristic rc ON rg.id = rc.geounit_id WHERE rc.subject_id = %%(subject_id)s AND rgg.geolevel_id = %%(geolevel_id)s;" % get_featuretype_name(geolevel.name, subject.name)
             cursor.execute(sql, {'subject_id':subject.id, 'geolevel_id':geolevel.id})
-            try:
-                transaction.commit()
-            except:
-                transaction.rollback()
-                logger.error('Failed to create %s view',
-                    get_featuretype_name(geolevel.name, subject.name))
-                logger.error(format_exc())
-
             logger.debug('Created %s view ...', get_featuretype_name(geolevel.name, subject.name))
-
-    try:
-        transaction.commit()
-    except:
-        transaction.rollback()
 
 def get_featuretype_name(geolevel_name, subject_name=None):
     """

--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -1192,12 +1192,10 @@ def add_districts_to_plan(request, planid):
     # Everything checks out, let's paste those districts
     try:
         results = plan.paste_districts(districts, version=version)
-        transaction.commit()
         status['success'] = True
         status['message'] = _('Merged %(num_merged_districts)d districts') % {'num_merged_districts': len(results)}
         status['version'] = plan.version
     except Exception as ex:
-        transaction.rollback()
         status['message'] = str(ex)
         status['exception'] = traceback.format_exc()
 
@@ -1264,14 +1262,12 @@ def assign_district_members(request, planid):
                 plan.update_num_members(district, count)
                 changed += 1
 
-        transaction.commit()
         status['success'] = True
         status['version'] = plan.version
         status['modified'] = changed
         status['message'] = _('Modified members for %(num_districts)d '
             'districts') % {'num_districts': changed}
     except Exception, ex:
-        transaction.rollback()
         status['message'] = str(ex)
         status['exception'] = traceback.format_exc()
         logger.warn('Could not assign district members')

--- a/django/publicmapping/setup.py
+++ b/django/publicmapping/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Set up DistrictBuilder.
 
@@ -50,9 +50,6 @@ def main():
     """
     usage = "usage: %prog [options] SCHEMA CONFIG"
     parser = OptionParser(usage=usage)
-    parser.add_option('-d', '--database', dest="database",
-            help="Generate the database schema", default=False,
-            action='store_true')
     parser.add_option('-g', '--geolevel', dest="geolevels",
             help="Import the geography from the Nth GeoLevel.",
             action="append", type="int")
@@ -76,12 +73,6 @@ def main():
             action='store_true', default=False),
     parser.add_option('-a', '--adjacency', dest="adjacency",
             help="Load adjacency data", default=False, action='store_true')
-    parser.add_option('-b', '--bard', dest="bard",
-            help="Create a BARD map based on the imported spatial data.",
-            default=False, action='store_true'),
-    parser.add_option('-B', '--bardtemplates', dest="bard_templates",
-            help="Create the BARD reporting templates.",
-            action='store_true', default=False),
     parser.add_option('-v', '--verbosity', dest="verbosity",
             help="Verbosity level; 0=minimal output, 1=normal output, 2=all output",
             default=1, type="int")
@@ -91,7 +82,16 @@ def main():
 
     (options, args) = parser.parse_args()
 
-    allops = (not options.database) and (not options.geolevels) and (not options.views) and (not options.geoserver) and (not options.templates) and (not options.nesting) and (not options.bard) and (not options.static) and (not options.languages) and (not options.bard_templates) and (not options.adjacency)
+    allops = not any([
+        options.geolevels,
+        options.views,
+        options.geoserver,
+        options.templates,
+        options.nesting,
+        options.static,
+        options.languages,
+        options.adjacency
+    ])
 
     setup_logging(options.verbosity)
 
@@ -135,6 +135,21 @@ ERROR:
     import django
     from django.core import management
     django.setup()
+
+    management.call_command(
+        'setup',
+        args[1], # config path
+        verbosity=options.verbosity,
+        geolevels=options.geolevels,
+        views=options.views,
+        geoserver=options.geoserver,
+        templates=options.templates,
+        nesting=options.nesting,
+        static=options.static,
+        languages=options.languages,
+        force=options.force,
+        adjacency=options.adjacency
+    )
 
     # Success! Exit-code 0
     sys.exit(0)

--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -145,14 +145,14 @@ as reports and downloads) and cron jobs.
     password authentication is allowed before user ident authentication
      
  7. Download the datafile to /projects/PublicMapping/data, and unzip into
-    the import directory: /projects/PublicMapping/local/data/:
+    the import directory: /data/:
 
     > sudo mkdir /projects/PublicMapping/data
     > cd /projects/PublicMapping/data
     > sudo wget --no-check-certificate -O VA_data.zip \
           https://s3.amazonaws.com/districtbuilderdata/VA_data.zip
-    > sudo mkdir /projects/PublicMapping/local/data
-    > cd /projects/PublicMapping/local/data
+    > sudo mkdir /data
+    > cd /data
     > sudo unzip /projects/PublicMapping/data/VA_data.zip
 
     *Note* that if you are loading spatial data for a coverage other than

--- a/docs/config.dist.xml
+++ b/docs/config.dist.xml
@@ -1018,7 +1018,7 @@
           
           -->
 
-          <Shapefile path="/projects/PublicMapping/local/data/tl_2010_51_block10_3785_join.shp">
+          <Shapefile path="/data/tl_2010_51_block10_3785_join.shp">
               <Fields>
                   <!-- 
 
@@ -1079,7 +1079,7 @@
           
           -->
           <Files>
-              <Geography path="/projects/PublicMapping/local/data/tl_2010_51_vtd10_3785.shp">
+              <Geography path="/data/tl_2010_51_vtd10_3785.shp">
                   <!-- 
 
                   Each Field item defines a field in the shapefile that
@@ -1133,7 +1133,7 @@
           
           -->
           <Files>
-              <Geography path="/projects/PublicMapping/local/data/tl_2010_51_county10_3785.shp">
+              <Geography path="/data/tl_2010_51_county10_3785.shp">
                   <!-- 
 
                   Each Field item defines a field in the shapefile that
@@ -1185,19 +1185,19 @@
             unit of geography, and 2) the district it belongs to.
             
             -->
-            <Blockfile path="/projects/PublicMapping/local/data/cd111_index.csv" />
+            <Blockfile path="/data/cd111_index.csv" />
         </Template>
         
         <Template name="State House">
             <LegislativeBody ref="house"/>
             
-            <Blockfile path="/projects/PublicMapping/local/data/sldl10_index.csv" />
+            <Blockfile path="/data/sldl10_index.csv" />
         </Template>
 
         <Template name="State Senate">
             <LegislativeBody ref="senate"/>
 
-            <Blockfile path="/projects/PublicMapping/local/data/sldu10_index.csv" />
+            <Blockfile path="/data/sldu10_index.csv" />
         </Template>
     </Templates>
     
@@ -1324,7 +1324,7 @@
             <BardConfigs>
                 <BardConfig 
                     id="tenpercent"
-                    shape="/projects/PublicMapping/local/data/vablock_bard_save.Rdata" 
+                    shape="/data/vablock_bard_save.Rdata" 
                     temp="/projects/PublicMapping/local/reports"
                     transform="/projects/PublicMapping/DistrictBuilder/docs/bard_template.xslt">
                     <PopVars>
@@ -1357,7 +1357,7 @@
                 </BardConfig>
                 <BardConfig 
                     id="fivepercent"
-                    shape="/projects/PublicMapping/local/data/vablock_bard_save.Rdata" 
+                    shape="/data/vablock_bard_save.Rdata" 
                     temp="/projects/PublicMapping/local/reports"
                     transform="/projects/PublicMapping/DistrictBuilder/docs/bard_template.xslt">
                     <PopVars>

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -16,19 +16,17 @@ Load a database dump from S3
 "
 }
 
-function load_shapefile() {
+function load_dev_data() {
     echo "Creating directory to download data into in django container"
     docker-compose \
         exec -T django mkdir -p /data
 
-    if [ -z "/data/VA_data.zip" ]; then
-        echo "Downloading shapefile"
-        docker-compose \
-            exec -T django \
-            wget -q \
-                -O /data/VA_data.zip \
-                https://s3.amazonaws.com/districtbuilderdata/VA_data.zip
-    fi
+    echo "Downloading shapefile"
+    docker-compose \
+        exec -T django \
+        wget -q \
+            -O /data/VA_data.zip \
+            https://s3.amazonaws.com/districtbuilderdata/VA_data.zip
 
     echo "Unzipping shapefile"
     docker-compose \
@@ -49,7 +47,10 @@ function load_shapefile() {
 
     echo "Loading shapefiles into geoserver"
     docker-compose \
-        exec -T django ./manage.py setup config/config.xml -g1
+        exec -T django ./manage.py setup config/config.xml -g0
+# TODO: performance is way too slow to import all three layers (-g2 is census blocks)
+#        exec -T django ./manage.py setup config/config.xml -g0 -g1 -g2
+
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
@@ -58,8 +59,8 @@ then
     then
         usage
     else
-        docker-compose up -d postgres
-        load_shapefile
+        docker-compose up -d postgres django
+        load_dev_data
     fi
     exit
 fi

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -45,7 +45,7 @@ function load_dev_data() {
     docker-compose \
         exec -T django ./manage.py migrate
 
-    echo "Loading shapefiles into geoserver"
+    echo "Loading shapefiles into database"
     docker-compose \
         exec -T django ./manage.py setup config/config.xml -g0
 # TODO: performance is way too slow to import all three layers (-g2 is census blocks)

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+
+if [[ -n "${DB_DEBUG}" ]]; then
+    set -x
+fi
+
+DIR="$(dirname "$0")"
+
+function usage() {
+
+    echo -n \
+"Usage: $(basename "$0")
+
+Load a database dump from S3
+"
+}
+
+function load_shapefile() {
+    echo "Creating directory to download data into in django container"
+    docker-compose \
+        exec -T django mkdir -p /data
+
+    if [ -z "/data/VA_data.zip" ]; then
+        echo "Downloading shapefile"
+        docker-compose \
+            exec -T django \
+            wget -q \
+                -O /data/VA_data.zip \
+                https://s3.amazonaws.com/districtbuilderdata/VA_data.zip
+    fi
+
+    echo "Unzipping shapefile"
+    docker-compose \
+        exec -T django \
+        unzip -o /data/VA_data.zip -d /data
+
+    echo "Drop district_builder database"
+    docker-compose \
+        exec -T postgres gosu postgres dropdb district_builder
+
+    echo "Create district_builder database"
+    docker-compose \
+        exec -T postgres gosu postgres createdb district_builder
+
+    echo "Running migrations"
+    docker-compose \
+        exec -T django ./manage.py migrate
+
+    echo "Loading shapefiles into geoserver"
+    docker-compose \
+        exec -T django ./manage.py setup config/config.xml -g1
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        docker-compose up -d postgres
+        load_shapefile
+    fi
+    exit
+fi

--- a/scripts/update
+++ b/scripts/update
@@ -19,11 +19,6 @@ function build_containers() {
 }
 
 
-function do_migrations() {
-    ./scripts/console django "./manage.py migrate"
-}
-
-
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
     if [ "${1:-}" = "--help" ]
@@ -32,9 +27,6 @@ then
     else
         echo "Building containers"
         build_containers
-
-        echo "Running migrations"
-        do_migrations
     fi
     exit
 fi


### PR DESCRIPTION
Overview
-----

This PR makes changes to make most `setup.py` flags work.

The (mostly) working flags are:

- `-gX` (load geolevels, very slow)
- `-V` (create database views)
- `-t` (create template plans)
- `-s` (collect static files)
- `-l` (create language files)

The broken flags are:

- `-G` (was blocked by `-gX`, may not be any more, but I'm out of time to investigate right now)
- `-a` (create adjacencies, depends on a data file that I don't have a good mock for)
- `-nX` (nest geolevel X, relies on old geos interface)

Remaining known issues with the flags are captured in #472.

It also removes several flags that existed to enable functionality that either is no longer intended or is no longer necessary with a more modern django.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

Testing
-----

- `docker-compose build`
- `./scripts/load_development_data` -- runs migrations, downloads a shapefile, loads shapes from the shapefile into the database (runs `setup.py ... -g0`, proving functionality). You can cancel this after a minute or two if you're feeling impatient.
- `docker-compose exec django bash`
- run `./setup.py config/config.xsd config/config.xml` with each of the other working flags above
- they should all succeed except `-t` and `-s`. `-t` depends on running I think `-g1` and also `-n1`. It has data dependencies. If you let `-g0` run for a little bit though, two plans succeed, which you can check with:

```python
>>> Plan.objects.count()
2
```

from the django shell. `-s` fails because I uninstalled `compressor` when I setup the dev environment :man_facepalming:. Should be an easy fix.
