### PR TITLE
Add Django logging

### DIFF
--- a/django/publicmapping/publicmapping/settings.py.in
+++ b/django/publicmapping/publicmapping/settings.py.in
@@ -209,6 +209,8 @@ STATICFILES_FINDERS = (
 
 SLD_ROOT = '/projects/PublicMapping/DistrictBuilder/sld/'
 
+WEB_TEMP = '/tmp'
+
 CONCURRENT_SESSIONS = 5
 SESSION_TIMEOUT = 15
 

--- a/django/publicmapping/publicmapping/settings.py.in
+++ b/django/publicmapping/publicmapping/settings.py.in
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+import logging.config
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -125,6 +126,34 @@ AUTH_PASSWORD_VALIDATORS = [
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
+
+
+LOGGING_CONFIG = None
+LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
+
+logging.config.dictConfig({
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'datefmt': '%Y-%m-%d %H:%M:%S %z',
+            'format': ('[%(asctime)s] [%(process)d] [%(levelname)s]'
+            ' %(message)s'),
+        }
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+            'level': LOG_LEVEL,
+        },
+    }
+})
 
 
 # Internationalization


### PR DESCRIPTION
## Overview

Configures logging for our Django app. It does so by configuring a root logger to write to the console based on the `LOG_LEVEL` environment variable (defaults to 'INFO').

## Testing

Check out the branch and copy over the settings file:
```
cp django/publicmapping/publicmapping/settings.py.in django/publicmapping/publicmapping/settings.py
```

Assuming you have `rsync-auto` running you should have `settings.py` on your VM.

Run `docker-compose up`. You should see requests being logged to the console as you access pages in DistrictBuilder like before.

You should now also see:

1. Tracebacks from any errors that are generated
2. Any 'INFO' level or higher logging

To drink from the fire hose, you can edit `docker-compose` like so:
```
   django:
     build:
       context: ./django/publicmapping
+    environment:
+      - LOG_LEVEL=DEBUG
     ports:
       - "8080:8080"
       - "8081:8081"
```

Note that 'DEBUG' level logs will include absolutely all Django logging, such as SQL queries and template errors,  and our logging.

I think seeing everything will be helpful in tracking down every error as we continue to fix things.

## Notes

I found this post to be helpful in understanding both Python and Django logging: https://lincolnloop.com/blog/django-logging-right-way/  
