### PR TITLE
Fix OpenLayers

### DIFF
--- a/django/publicmapping/redistricting/models.py
+++ b/django/publicmapping/redistricting/models.py
@@ -82,11 +82,11 @@ class BaseModel(models.Model):
         lang = translation.get_language()
         if not lang in I18N_CACHE:
             try:
-                path = os.path.join(settings.MEDIA_ROOT, '../locale/%s/LC_MESSAGES/xmlconfig.mo' % lang)
+                path = os.path.join(settings.STATIC_ROOT, '../locale/%s/LC_MESSAGES/xmlconfig.mo' % lang)
                 path = os.path.normpath(path)
                 I18N_CACHE[lang] = polib.mofile(path)
             except Exception, ex:
-                path = os.path.join(settings.MEDIA_ROOT, '../locale/%s/LC_MESSAGES/xmlconfig.po' % lang)
+                path = os.path.join(settings.STATIC_ROOT, '../locale/%s/LC_MESSAGES/xmlconfig.po' % lang)
                 path = os.path.normpath(path)
                 I18N_CACHE[lang] = polib.pofile(path)
 

--- a/django/publicmapping/redistricting/static/js/mapping.js
+++ b/django/publicmapping/redistricting/static/js/mapping.js
@@ -152,7 +152,7 @@ function init() {
     // set the max extent to be the boundaries of the world in
     // spherical mercator to avoid all geowebcache offset issues
     var max = 20037508.342789244;
-    var srs = "EPSG:3785";
+    var srs = "EPSG:3857";
     var extent = new OpenLayers.Bounds(-max, -max, max, max);
 
     // ensure the page is fully loaded before the map is initialized
@@ -275,8 +275,6 @@ function mapinit(srs,maxExtent) {
     // These layers are dependent on the layers available in geowebcache
     var layers = [];
 
-    
-
     // Calculate the minimum zoom level based on the extent of the study area
     var studyWidthMeters = STUDY_EXTENT[2] - STUDY_EXTENT[0];
     var studyHeightMeters = STUDY_EXTENT[3] - STUDY_EXTENT[1];
@@ -290,7 +288,7 @@ function mapinit(srs,maxExtent) {
     // zoom = log(maxmpp/mpp)/log(2)
     var hlevel = Math.log(maxMetersPerPixel / hMetersPerPixel) / Math.LN2;
     var vlevel = Math.log(maxMetersPerPixel / vMetersPerPixel) / Math.LN2;
-    
+
     var minZoomLevel = (hlevel < vlevel) ? Math.floor(hlevel) : Math.floor(vlevel);
     var maxZoomLevel = 17; // This level is far enough zoomed to view blocks in any state
     var numZoomLevels = maxZoomLevel - minZoomLevel + 1;
@@ -315,7 +313,7 @@ function mapinit(srs,maxExtent) {
                     hybrid: VEMapStyle.Hybrid,
                     road: VEMapStyle.Road 
                 };
-    
+
                 options.type = types[mapType];
                 if (options.type) {
                     return new OpenLayers.Layer.VirtualEarth(layerName, options);
@@ -330,13 +328,13 @@ function mapinit(srs,maxExtent) {
                     sphericalMercator: true,
                     maxExtent: maxExtent
                 };
-                
+
                 types = {
                     aerial: G_SATELLITE_MAP,
                     hybrid: G_HYBRID_MAP, 
                     road: G_NORMAL_MAP
                 };
-    
+
                 options.type = types[mapType];
                 if (options.type) {
                     return new OpenLayers.Layer.Google(layerName, options);
@@ -420,7 +418,7 @@ function mapinit(srs,maxExtent) {
         layer.setVisibility(false);
         layers.push(layer);
     }
-    
+
     // Set up the opacity slider and connect change events to control the base and thematic layer opacities
     $('#opacity_slider').slider({
         value: 100 - defaultThematicOpacity * 100,
@@ -439,7 +437,7 @@ function mapinit(srs,maxExtent) {
         var id = 'radio' + i;
         var button = $('<input type="radio" name="basemap" id="' + id + '"' + ((i === 0) ? 'checked=checked' : '') +
                        ' /><label for="' + id + '">' + ((layers.length === 1) ? gettext("Map Transparency") : layer.name) + '</label>');
-            
+
         // change the base layer when a new one is selected
         button.click(function() {
             olmap.setBaseLayer(layer);
@@ -464,7 +462,7 @@ function mapinit(srs,maxExtent) {
             resizable:false,
             open: function() { $(".ui-dialog-titlebar-close", $(this).parent()).hide(); }                    
         });
-        
+
         $.ajax({
             type: 'POST',
             url: '/districtmapping/plan/' + PLAN_ID + '/fixunassigned/',
@@ -484,13 +482,13 @@ function mapinit(srs,maxExtent) {
                         text: gettext('OK'),
                         click: function() { $(this).dialog('close'); }
                     }]
-                });                
+                });
             },
             error: function(xhr, textStatus, error) {
-                pleaseWait.remove();                        
+                pleaseWait.remove();
                 $('<div />').text(gettext('Error encountered while fixing unassigned')).dialog({
                     modal: true, autoOpen: true, title: gettext('Error'), resizable:false
-                });                
+                });
             }
         });
     });
@@ -518,7 +516,7 @@ function mapinit(srs,maxExtent) {
         } else {
             urlSuffix = 'geolevel/' + referenceLayerId.substring('geolevel.'.length);
         }
-    
+
         var waitDialog = $('<div />').text(gettext('Please wait. Querying for splits.'))
                 .dialog({
             modal: true,
@@ -526,7 +524,7 @@ function mapinit(srs,maxExtent) {
             title: gettext('Finding Splits'),
             escapeOnClose: false,
             resizable:false,
-            open: function() { $(".ui-dialog-titlebar-close", $(this).parent()).hide(); }                    
+            open: function() { $(".ui-dialog-titlebar-close", $(this).parent()).hide(); }
         });
 
         $.ajax({
@@ -649,7 +647,7 @@ function mapinit(srs,maxExtent) {
                 min_layer = snap_layer;
             }
         }
-        
+
         return { 
             layer: min_layer.layer, 
             level: min_layer.level,

--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -551,7 +551,7 @@ def commonplan(request, planid):
         'body_member_long_label': long_label,
         'body_members': body_members,
         'reporting_template': reporting_template,
-        'study_area_extent': study_area_extent.coords,
+        'study_area_extent': list(study_area_extent.extent),
         'has_leaderboard' : len(ScoreDisplay.objects.filter(is_page=True)) > 0,
         'calculator_reports' : json.dumps(calculator_reports),
         'allow_email_submissions': (


### PR DESCRIPTION
# Overview
This fixes the "Invalid array length" error thrown by OpenLayers when trying to load the plan view page. The issue appears to have been a change in the behavior of GeoDjango although I didn't go through the Django changelogs to verify. The `MultiPolygon.coords` attribute currently returns the coordinates for the entire geometry, but the front-end Javascript is expecting a 4-element bounding box array of [xmin, ymin, xmax, ymax]. Additionally, the coordinates were returned as a tuple rather than an array, which is evaluated by Javascript as the final element of the tuple, i.e. (w, x, y, z) => z. This fixes both problems.

This also fixes a problem with `MEDIA_ROOT` being used to access `.po` files; Django has since introduced a `STATIC_ROOT` variable that should be used in this case (and indeed, we are currently storing the `.po` files in `STATIC_ROOT`, rather than `MEDIA_ROOT`), so this switches to that.

# Demo
<img width="1437" alt="screen shot 2018-01-05 at 11 11 19 am" src="https://user-images.githubusercontent.com/447977/34617587-edd6df1c-f209-11e7-8abf-181ce96285dc.png">

# Testing instructions
- Get your VM and `./scripts/server` started. This assumes you've run all `load_development_data` and `./manage.py setup` commands necessary to get a basic instance going.
- Run `docker exec -ti vagrant_django_1 bash` and then `./manage.py collectstatic --noinput` to make sure you have updated static files (this needs to happen every time rsync triggers so if you run into errors about OpenLayers not being defined, just rerun it).
- Log in as guest and view the example plan.
- You should see a map, and it should be centered on Virginia. 🎉 