### PR TITLE
Fix reporting

### DIFF
--- a/django/publicmapping/Dockerfile
+++ b/django/publicmapping/Dockerfile
@@ -13,4 +13,4 @@ COPY . /usr/src/app
 
 WORKDIR /usr/src/app
 
-ENTRYPOINT ["/usr/local/bin/gunicorn"]
+ENTRYPOINT ["/usr/src/app/run_django.sh"]

--- a/django/publicmapping/publicmapping/settings.py.in
+++ b/django/publicmapping/publicmapping/settings.py.in
@@ -29,6 +29,14 @@ DEBUG = True
 ALLOWED_HOSTS = []
 
 
+# Settings for django-celery process queue
+import djcelery
+djcelery.setup_loader()
+
+# TODO: Don't use Django as broker
+BROKER_URL = 'django://'
+
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -46,6 +54,8 @@ INSTALLED_APPS = [
     'polib',
     'rosetta',
     'tagging',
+    'djcelery',
+    'kombu.transport.django',
 
     # local
     'publicmapping',

--- a/django/publicmapping/publicmapping/urls.py
+++ b/django/publicmapping/publicmapping/urls.py
@@ -50,5 +50,7 @@ urlpatterns = (
         url(r'^i18n/', include('django.conf.urls.i18n'))
     ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
+    # TODO: Serve reports a better way
+    + static('/reports/', document_root=settings.STATIC_ROOT)
 )
 

--- a/django/publicmapping/redistricting/models.py
+++ b/django/publicmapping/redistricting/models.py
@@ -3255,7 +3255,8 @@ class ScoreFunction(BaseModel):
         Returns:
             An instance of the requested calculator.
         """
-        parts = self.calculator.split('.')
+        # TODO: Don't store fully qualified name of the module in the database
+        parts = self.calculator.split('.')[1:]
         module = ".".join(parts[:-1])
         m = __import__( module )
         for comp in parts[1:]:

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -1114,6 +1114,11 @@ def cleanup():
     management.call_command('cleanup')
 
 
+# TODO: Serve temp files appropriately. This is a stopgap solution to show
+# report generation working end to end by serving them as static files.
+tempdir = settings.STATIC_ROOT
+
+
 class PlanReport:
     """
     A collection of static methods that assist in asynchronous report
@@ -1143,7 +1148,6 @@ class PlanReport:
                         planid)
             return
 
-        tempdir = settings.WEB_TEMP
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
 
@@ -1238,7 +1242,6 @@ class PlanReport:
         except:
             return 'error'
 
-        tempdir = settings.WEB_TEMP
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
 
@@ -1270,7 +1273,6 @@ class PlanReport:
         except:
             return 'error'
 
-        tempdir = settings.WEB_TEMP
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
 
@@ -1345,7 +1347,6 @@ class CalculatorReport:
         })
 
         # Write it to file
-        tempdir = settings.WEB_TEMP
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
         html_file_path = '%s/%s.html' % (tempdir, filename)
@@ -1369,7 +1370,6 @@ class CalculatorReport:
         except:
             return 'error'
 
-        tempdir = settings.WEB_TEMP
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
         pending_file = '%s/%s.pending' % (tempdir, filename)
@@ -1395,7 +1395,6 @@ class CalculatorReport:
         except:
             return 'error'
 
-        tempdir = settings.WEB_TEMP
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
 

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -1348,13 +1348,10 @@ class CalculatorReport:
         tempdir = settings.WEB_TEMP
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
-        htmlfile = open(
-            '%s/%s.html' % (
-                tempdir,
-                filename,
-            ), mode='w', encoding='utf=8')
-        htmlfile.write(html)
-        htmlfile.close()
+        html_file_path = '%s/%s.html' % (tempdir, filename)
+
+        with open(html_file_path, mode='w', encoding='utf=8') as html_file:
+            html_file.write(html)
 
         # reset the language back to default
         if not prev_lang is None:

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -25,7 +25,6 @@ Author:
 """
 
 from celery.task import task
-from celery.task.http import HttpDispatchTask
 from codecs import open
 from django.core import management
 from django_comments.models import Comment

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -1336,8 +1336,7 @@ class CalculatorReport:
                 name='%s_reports' % plan.legislative_body.name)
             html = display.render(plan, request, function_ids=function_ids)
         except Exception as ex:
-            logger.warn('Error creating calculator report')
-            logger.debug('Reason: %s', ex)
+            logger.exception('Error creating calculator report')
             html = _('Error creating calculator report.')
 
         # Add to report container template

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -20,7 +20,7 @@ License:
     See the License for the specific language governing permissions and
     limitations under the License.
 
-Author: 
+Author:
     Andrew Jennings, David Zwarg
 """
 
@@ -31,7 +31,7 @@ from django_comments.models import Comment
 from django.contrib.sessions.models import Session
 from django.contrib.sites.models import Site
 from django.core.mail import send_mail, mail_admins, EmailMessage
-from django.template import loader, Context as DjangoContext
+from django.template import loader
 from django.db import connection, transaction
 from django.db.models import Sum, Min, Max, Avg
 from django.conf import settings
@@ -82,7 +82,7 @@ class DistrictFile():
         """
         Given a plan, this method will check to see whether the district file
         for the given plan exists, is pending, or has not been created.
-        
+
         Parameters:
             plan - the Plan for which a file has been requested
             shape - a flag indicating if this is to be a shapefile; defaults to False
@@ -102,13 +102,13 @@ class DistrictFile():
     def get_file(plan, shape=False):
         """
         Given a plan, return the district file for the plan at the current version.
-        
+
         Parameters:
             plan - the Plan for which a file has been requested.
             shape - a flag indicating if this is to be a shapefile; defaults to False
 
         Returns:
-            A file object representing the district file. If the file requested 
+            A file object representing the district file. If the file requested
             doesn't exist, nothing is returned.
         """
         if (DistrictFile.get_file_status(plan, shape) == 'done'):
@@ -123,10 +123,10 @@ class DistrictIndexFile():
     The publicmapping projects supports users importing and exporting
     their plans to district index files.  These two-column, csv-formatted
     files list all of the base geounits in a plan and to which district they
-    belong.  
+    belong.
 
     These files may be uploaded or downloaded in .zip format. The files
-    should not contain a header row - rows which do not contain a 
+    should not contain a header row - rows which do not contain a
     portable id from the database will be ignored.
     """
 
@@ -141,15 +141,15 @@ class DistrictIndexFile():
                    email=None,
                    language=None):
         """
-        Imports a plan using a district index file in csv format. 
-        There should be only two columns: a CODE matching the 
+        Imports a plan using a district index file in csv format.
+        There should be only two columns: a CODE matching the
         portable ids of geounits and a DISTRICT integer
         representing the district to which the geounit should belong.
 
         Parameters:
             name - The name of the Plan.
             filename - The path to the district index file.
-            owner - Optional. The user who owns this plan. If not 
+            owner - Optional. The user who owns this plan. If not
                 specified, defaults to the system admin.
             template - Optional. A flag indicating that this new plan
                 is a template that other users can instantiate.
@@ -170,9 +170,10 @@ class DistrictIndexFile():
             error_subject = _("Problem importing your uploaded file.")
             success_subject = _("Upload and import plan confirmation.")
             admin_subject = _("Problem importing user uploaded file.")
-
-            context = DjangoContext({'user': owner, 'errors': list()})
-
+            context = {
+                'user': owner,
+                'errors': list()
+            }
         # Is this filename a zip archive?
         if filename.endswith('.zip'):
             try:
@@ -567,7 +568,7 @@ class DistrictIndexFile():
 
         Parameters:
             plan - The plan for which to get an index file
-        
+
         Returns:
             A file object representing the zipped index file
         """
@@ -655,7 +656,7 @@ class DistrictIndexFile():
 
         # Add it as an attachment and send the email
         template = loader.get_template('submission.email')
-        context = DjangoContext({'user': user, 'plan': plan, 'post': post})
+        context = {'user': user, 'plan': plan, 'post': post}
         email = EmailMessage()
         email.subject = _(
             'Competition submission (user: %(username)s, planid: %(plan_id)d)'
@@ -673,7 +674,7 @@ class DistrictIndexFile():
         subject = _("Plan submitted successfully")
         user_email = post['email']
         template = loader.get_template('submitted.email')
-        context = DjangoContext({'user': user, 'plan': plan})
+        context = {'user': user, 'plan': plan}
         send_mail(
             subject,
             template.render(context),
@@ -687,7 +688,7 @@ class DistrictIndexFile():
 
 class DistrictShapeFile():
     """
-    The publicmapping projects supports users exporting their plans to 
+    The publicmapping projects supports users exporting their plans to
     shape files.  These files list all of the districts, their geometries,
     and the computed characteristics of the plan's districts.
 
@@ -803,7 +804,7 @@ class DistrictShapeFile():
                     }
                 }
             },
-            'eainfo': {  # FGDC 5 
+            'eainfo': {  # FGDC 5
                 'detailed': {
                     'enttype': {
                         'enttypl':
@@ -890,7 +891,7 @@ class DistrictShapeFile():
 
         Parameters:
             plan - The plan for which to get a shape file
-        
+
         Returns:
             A file object representing the zipped shape file
         """
@@ -1340,10 +1341,9 @@ class CalculatorReport:
             html = _('Error creating calculator report.')
 
         # Add to report container template
-        html = loader.get_template('report_panel_container.html').render(
-            DjangoContext({
-                'report_panels': html
-            }))
+        html = loader.get_template('report_panel_container.html').render({
+            'report_panels': html
+        })
 
         # Write it to file
         tempdir = settings.WEB_TEMP
@@ -2115,11 +2115,9 @@ def clean_quarantined(upload_id, language=None):
         logger.warn('Could not reset the is_valid flag on all plans.')
 
     status = {
-        'task_id':
-        None,
-        'success':
-        True,
-        'messages': [
+        'task_id':None,
+        'success':True,
+        'messages':[
             _('Upload complete. Subject "%(subject_name)s" added.') % {
                 'subject_name': upload.subject_name
             }

--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -45,7 +45,7 @@ from django.contrib.gis.gdal import *
 from django.contrib.gis.gdal.libgdal import lgdal
 from django.contrib.sites.models import Site
 from django.contrib import humanize
-from django.template import loader, Context as DjangoContext
+from django.template import loader
 from django.template.context_processors import csrf
 from django.utils import translation
 from django.utils.translation import ugettext as _, ungettext as _n
@@ -754,7 +754,7 @@ def printplan(request, planid):
 
         # render pg to a string
         t = loader.get_template('printplan.html')
-        page = t.render(DjangoContext(cfg))
+        page = t.render(cfg)
         result = StringIO.StringIO()
 
         # setting encoding='UTF-8' causes an exception. removing this for now,
@@ -1484,13 +1484,12 @@ def get_splits_report(request, planid):
         report = loader.get_template('split_report.html')
         html = ''
         for layer in layers:
-            my_context = {'extended': extended}
-            my_context.update(plan.compute_splits(layer, version = version, inverse = inverse, extended = extended))
+            calc_context = {'extended': extended}
+            calc_context.update(plan.compute_splits(layer, version = version, inverse = inverse, extended = extended))
             last_item = layer is layers[-1]
             community_info = plan.get_community_type_info(layer, version = version, inverse = inverse, include_counts=last_item)
             if community_info is not None:
-                my_context.update(community_info)
-            calc_context = DjangoContext(my_context)
+                calc_context.update(community_info)
             html += report.render(calc_context)
             if not last_item:
                 html += '<hr />'
@@ -2621,7 +2620,7 @@ def plan_feed(request):
         'width': width,
         'height': height
     }
-    xml = feed.render(DjangoContext(context))
+    xml = feed.render(context)
 
     return HttpResponse(xml, content_type='application/atom+xml')
 
@@ -2654,6 +2653,6 @@ def share_feed(request):
         'width': width,
         'height': height
     }
-    xml = feed.render(DjangoContext(context))
+    xml = feed.render(context)
 
     return HttpResponse(xml, content_type='application/atom+xml')

--- a/django/publicmapping/requirements.txt
+++ b/django/publicmapping/requirements.txt
@@ -3,9 +3,8 @@ ipython==5.5.0
 gevent==1.2.2
 Django==1.11.5
 psycopg2==2.7.3
-celery==3.0.15
-kombu==3.0.37
-django-celery==3.0.11
+celery==3.1.25
+django-celery==3.2.2
 django-redis==4.8.0
 django-rosetta==0.7.13
 django-staticfiles==1.2.1

--- a/django/publicmapping/run_django.sh
+++ b/django/publicmapping/run_django.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Run celery worker in background
+# TODO: Don't use C_FORCE_ROOT
+C_FORCE_ROOT=1 python manage.py celery worker --loglevel=info &
+
+# Run Django with Gunicorn
+/usr/local/bin/gunicorn \
+  --workers=2 \
+  --timeout=60 \
+  --bind=0.0.0.0:8080 \
+  --reload \
+  --log-level=debug \
+  --access-logfile=- \
+  --error-logfile=- \
+  -kgevent \
+  publicmapping.wsgi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,16 +23,6 @@ services:
       - "8081:8081"
     volumes:
       - ./django/publicmapping/:/usr/src/app/
-    command:
-      - "--workers=2"
-      - "--timeout=60"
-      - "--bind=0.0.0.0:8080"
-      - "--reload"
-      - "--log-level=debug"
-      - "--access-logfile=-"
-      - "--error-logfile=-"
-      - "-kgevent"
-      - "publicmapping.wsgi"
     links:
       - postgres:postgres.internal.districtbuilder.com
       - redis:redis.internal.districtbuilder.com


### PR DESCRIPTION
## Overview
This PR makes reporting work. It punts on all major architectural decisions just to get things working.

## Testing
1. Run `./scripts/reconfig`
1. `vagrant up && vagrant ssh`
1. Within VM, `docker-compose build && docker-compose up`
1. Log in to DistrictBuilder as a guest
1. Go to the "Evaluate" tab (http://localhost:8080/districtmapping/plan/1/view/)
1. Click any report and then click "Create and Preview New Report"
1. See the report in the preview. Notice that the "Open Current Report in New Window" also works.

## Notes
This PR does not address much tech debt that carried over from the original DistrictBuilder. It does pretty much the bare minimum to get things working. Here is the outstanding tech debt that is carrying over as I see it:
* Continues to use [django-celery](https://github.com/celery/django-celery) which is old, looks abandoned, and which we don't need to use anymore AFAICT
* Uses Django as the message broker for celery which is [not recommended](http://docs.celeryproject.org/en/3.1/getting-started/brokers/django.html)
* Upgraded Celery to `3.1.25` but cannot upgrade to the newest version `4.1.0` because that version is not supported by `django-celery` (I found this out the hard way because pip isn't great at dependency resolution...)
* Uses `C_FORCE_ROOT=1` to run Celery as root, which the 4.1.0 documentation calls ["a very dangerous practice"](http://docs.celeryproject.org/en/latest/userguide/daemonizing.html#running-the-worker-with-superuser-privileges-root)
* Continues storing the fully qualified name of the calculator module in the database (predictably, this turned out not to be a robust solution):
```
In [1]: from redistricting.models import ScoreFunction

In [2]: sf = ScoreFunction.objects.all()[0]

In [3]: sf
Out[3]: <ScoreFunction: a_congressional_population label>

In [4]: sf.calculator
Out[4]: u'publicmapping.redistricting.calculators.Interval'
```
* Does not resolve the issue of serving files we generate, such as reports. Previously they were served by Apache and we could use Nginx to do the same thing but that was too much to tackle at the moment.

However, it does make things work and upgrades our deps as far we can.

We can talk about how to address all of the above issues.