### PR TITLE
Don't require manage.py collectstatic on every server run

### DIFF
--- a/django/publicmapping/Dockerfile
+++ b/django/publicmapping/Dockerfile
@@ -13,4 +13,6 @@ COPY . /usr/src/app
 
 WORKDIR /usr/src/app
 
+RUN python manage.py collectstatic --noinput
+
 ENTRYPOINT ["/usr/local/bin/gunicorn"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "8081:8081"
     volumes:
       - ./django/publicmapping/:/usr/src/app/
+      - /usr/src/app/static
     command:
       - "--workers=2"
       - "--timeout=60"


### PR DESCRIPTION
## Overview
Fixes issue where `collectstatic` would have to be run each time a file was changed.

## Testing
`docker-compose build && docker-compose up` should do it. Notice you don't need to run `collectstatic` to see the map (kind of) working before or after any changes.

## PivotalTracker
https://www.pivotaltracker.com/n/projects/2140015/stories/154063082

## Notes
I've uncovered some weirdness around how we serve static files. Currently we have two `static/` directories checked into source control, one of which is our `STATIC_ROOT`:
```
10:29 $ find -type d -name static
./django/publicmapping/redistricting/static
./django/publicmapping/static
```
They both contain some of the same files, some of which are only slightly different. Presumably the common files in our `STATIC_ROOT` (`django/publicmapping/static`) are getting overwritten by the app-specific static files when we run `collectstatic`, though I'm not entirely sure of that.

@kshepard has mentioned doing away with `collectstatic` entirely which might be a good option but I'm going to hold off on any major changes for now just so we can move forward and address this immediate annoying issue.

It's also worth noting that with our current setup, if you're doing frontend work you would still need to run `collectstatic` to have your changes to static files reflected, which is something that we should address.