### PR TITLE
Fix usage of static template tag so that jqGrid loads

### DIFF
--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -67,7 +67,9 @@
     <script type="text/javascript" src="{% static 'jquery/jquery-1.6.2.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'jquery/jquery-ui-1.8.16.custom.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'jquery/external/jquery.tools.tooltip.slide.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'jqGrid/js/i18n/grid.locale-{{ language_code }}.js' %}"></script>
+    {% with jqgrid_locale_path="jqGrid/js/i18n/grid.locale-"|add:language_code|add:".js" %}
+    <script type="text/javascript" src="{% static jqgrid_locale_path %}"></script>
+    {% endwith %}
     <script type="text/javascript" src="{% static 'jqGrid/js/jquery.jqGrid.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'jqGrid/plugins/grid.postext.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/sprintf.js' %}"></script>


### PR DESCRIPTION
## Overview

jqGrid wasn't being loaded because we were attempting to do a variable interpolation within a template tag, which isn't allowed. I'm not a huge fan of the fix but it seems to be standard practice. https://stackoverflow.com/questions/16655851/django-1-5-how-to-use-variables-inside-static-tag

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

Take a gander at these beautiful paginator arrows:
![dbjqgrid](https://user-images.githubusercontent.com/447977/34959174-40359874-fa03-11e7-8e4e-c8a580ac8116.png)

## Testing Instructions

 * Enter as a guest. 
 * You should see pagination controls on the plan list view, and they shouldn't have a big `undefined` obscuring them.

[fix #154033194]