### PR TITLE
Add .travis.yml for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+services:
+  - docker
+
+install:
+  - ./scripts/update
+
+script:
+  - ./scripts/test

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -5,8 +5,6 @@ if [[ -n "${DB_DEBUG}" ]]; then
     set -x
 fi
 
-DIR="$(dirname "$0")"
-
 function usage() {
 
     echo -n \


### PR DESCRIPTION
## Overview

Add a travis file to enable CI. This will enable tests to run on Travis when this and the [make tests run PR](https://github.com/PublicMapping/DistrictBuilder/pull/489) is merged into develop.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Look at the travis build for this branch.
