### PR TITLE
Fix reporting (part deux)

### DIFF
--- a/django/publicmapping/Dockerfile
+++ b/django/publicmapping/Dockerfile
@@ -6,6 +6,8 @@ RUN mkdir -p /opt/sld
 RUN mkdir -p /opt/reports
 
 # Create reporter user that can write to reports directory
+# This user is used to run `celery worker` for reporting
+# as it is not recommended to run Celery services as root.
 RUN useradd -m reporter
 RUN chown reporter: /opt/reports
 

--- a/django/publicmapping/Dockerfile
+++ b/django/publicmapping/Dockerfile
@@ -2,6 +2,13 @@ FROM quay.io/azavea/django:1.11-python2.7-slim
 
 RUN mkdir -p /usr/src/app
 RUN mkdir -p /opt/sld
+
+RUN mkdir -p /opt/reports
+
+# Create reporter user that can write to reports directory
+RUN useradd -m reporter
+RUN chown reporter: /opt/reports
+
 WORKDIR /usr/src/app
 
 COPY requirements.txt /usr/src/app/
@@ -14,5 +21,3 @@ COPY . /usr/src/app
 WORKDIR /usr/src/app
 
 RUN cp config/config.dist.xml config/config.xml
-
-ENTRYPOINT ["/usr/local/bin/gunicorn"]

--- a/django/publicmapping/publicmapping/celery.py
+++ b/django/publicmapping/publicmapping/celery.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, unicode_literals
+import os
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "publicmapping.settings")
+
+# Configure Celery app to use Redis as both the results backend and the message broker.
+app = Celery('publicmapping', backend='redis://redis', broker='redis://redis')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()

--- a/django/publicmapping/publicmapping/settings.py
+++ b/django/publicmapping/publicmapping/settings.py
@@ -176,6 +176,8 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = '/usr/src/app/static/'
 
+REPORTS_ROOT = '/opt/reports'
+
 # LEGACY SETTINGS
 
 # Location of your key value store, e.g., Redis

--- a/django/publicmapping/redistricting/models.py
+++ b/django/publicmapping/redistricting/models.py
@@ -3630,7 +3630,8 @@ class ScoreFunction(BaseModel):
         Returns:
             An instance of the requested calculator.
         """
-        parts = self.calculator.split('.')
+        # TODO: Don't store fully qualified name of the module in the database
+        parts = self.calculator.split('.')[1:]
         module = ".".join(parts[:-1])
         m = __import__(module)
         for comp in parts[1:]:

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -25,7 +25,6 @@ Author:
 """
 
 from publicmapping.celery import app
-# from celery.task.http import HttpDispatchTask
 from codecs import open
 from django.core import management
 from django_comments.models import Comment

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -1321,8 +1321,9 @@ class CalculatorReport:
         try:
             plan = Plan.objects.get(pk=planid)
         except:
-            logger.debug("Couldn't retrieve plan information for plan %d",
-                         planid)
+            logger.exception(
+                "Couldn't retrieve plan information for plan {}".format(planid)
+            )
             return
 
         function_ids = map(lambda s: int(s), request['functionIds'].split(','))

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -20,7 +20,7 @@ License:
     See the License for the specific language governing permissions and
     limitations under the License.
 
-Author: 
+Author:
     Andrew Jennings, David Zwarg
 """
 
@@ -83,7 +83,7 @@ class DistrictFile():
         """
         Given a plan, this method will check to see whether the district file
         for the given plan exists, is pending, or has not been created.
-        
+
         Parameters:
             plan - the Plan for which a file has been requested
             shape - a flag indicating if this is to be a shapefile; defaults to False
@@ -103,13 +103,13 @@ class DistrictFile():
     def get_file(plan, shape=False):
         """
         Given a plan, return the district file for the plan at the current version.
-        
+
         Parameters:
             plan - the Plan for which a file has been requested.
             shape - a flag indicating if this is to be a shapefile; defaults to False
 
         Returns:
-            A file object representing the district file. If the file requested 
+            A file object representing the district file. If the file requested
             doesn't exist, nothing is returned.
         """
         if (DistrictFile.get_file_status(plan, shape) == 'done'):
@@ -124,10 +124,10 @@ class DistrictIndexFile():
     The publicmapping projects supports users importing and exporting
     their plans to district index files.  These two-column, csv-formatted
     files list all of the base geounits in a plan and to which district they
-    belong.  
+    belong.
 
     These files may be uploaded or downloaded in .zip format. The files
-    should not contain a header row - rows which do not contain a 
+    should not contain a header row - rows which do not contain a
     portable id from the database will be ignored.
     """
 
@@ -142,15 +142,15 @@ class DistrictIndexFile():
                    email=None,
                    language=None):
         """
-        Imports a plan using a district index file in csv format. 
-        There should be only two columns: a CODE matching the 
+        Imports a plan using a district index file in csv format.
+        There should be only two columns: a CODE matching the
         portable ids of geounits and a DISTRICT integer
         representing the district to which the geounit should belong.
 
         Parameters:
             name - The name of the Plan.
             filename - The path to the district index file.
-            owner - Optional. The user who owns this plan. If not 
+            owner - Optional. The user who owns this plan. If not
                 specified, defaults to the system admin.
             template - Optional. A flag indicating that this new plan
                 is a template that other users can instantiate.
@@ -570,7 +570,7 @@ class DistrictIndexFile():
 
         Parameters:
             plan - The plan for which to get an index file
-        
+
         Returns:
             A file object representing the zipped index file
         """
@@ -690,7 +690,7 @@ class DistrictIndexFile():
 
 class DistrictShapeFile():
     """
-    The publicmapping projects supports users exporting their plans to 
+    The publicmapping projects supports users exporting their plans to
     shape files.  These files list all of the districts, their geometries,
     and the computed characteristics of the plan's districts.
 
@@ -806,7 +806,7 @@ class DistrictShapeFile():
                     }
                 }
             },
-            'eainfo': {  # FGDC 5 
+            'eainfo': {  # FGDC 5
                 'detailed': {
                     'enttype': {
                         'enttypl':
@@ -893,7 +893,7 @@ class DistrictShapeFile():
 
         Parameters:
             plan - The plan for which to get a shape file
-        
+
         Returns:
             A file object representing the zipped shape file
         """

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -24,8 +24,8 @@ Author:
     Andrew Jennings, David Zwarg
 """
 
-from celery.task import task
-from celery.task.http import HttpDispatchTask
+from publicmapping.celery import app
+# from celery.task.http import HttpDispatchTask
 from codecs import open
 from django.core import management
 from django_comments.models import Comment
@@ -132,7 +132,7 @@ class DistrictIndexFile():
     """
 
     @staticmethod
-    @task
+    @app.task
     def index2plan(name,
                    body,
                    filename,
@@ -562,7 +562,7 @@ class DistrictIndexFile():
             activate(prev_lang)
 
     @staticmethod
-    @task
+    @app.task
     def plan2index(plan):
         """
         Gets a zipped copy of the district index file for the
@@ -636,7 +636,7 @@ class DistrictIndexFile():
         return DistrictFile.get_file(plan)
 
     @staticmethod
-    @task
+    @app.task
     def emailfile(plan, user, post, language=None):
         """
         Email an archived district index file to a user.
@@ -886,7 +886,7 @@ class DistrictShapeFile():
         output.close()
 
     @staticmethod
-    @task
+    @app.task
     def plan2shape(plan):
         """
         Gets a zipped copy of the plan shape file.
@@ -1106,7 +1106,7 @@ class DistrictShapeFile():
         return DistrictFile.get_file(plan, True)
 
 
-@task
+@app.task
 def cleanup():
     """
     Clean out all the old sessions.
@@ -1123,7 +1123,7 @@ class PlanReport:
     """
 
     @staticmethod
-    @task
+    @app.task
     def createreport(planid, stamp, request, language=None):
         """
         Create the data structures required for a BARD report, and call
@@ -1305,7 +1305,7 @@ class CalculatorReport:
     """
 
     @staticmethod
-    @task
+    @app.task
     def createcalculatorreport(planid, stamp, request, language=None):
         """
         Create the report.
@@ -1429,7 +1429,7 @@ class CalculatorReport:
 #
 # Reaggregation tasks
 #
-@task
+@app.task
 def reaggregate_plan(plan_id):
     """
     Asynchronously reaggregate all computed characteristics for each district in the plan.
@@ -1464,7 +1464,7 @@ def reaggregate_plan(plan_id):
 #
 # Validation tasks
 #
-@task
+@app.task
 def validate_plan(plan_id):
     """
     Asynchronously validate a plan.
@@ -1499,7 +1499,7 @@ def validate_plan(plan_id):
     return is_valid
 
 
-@task
+@app.task
 @transaction.atomic
 def verify_count(upload_id, localstore, language):
     """
@@ -1615,7 +1615,7 @@ def verify_count(upload_id, localstore, language):
     return status
 
 
-@task
+@app.task
 def verify_preload(upload_id, language=None):
     """
     Continue the verification process by counting the number of geounits
@@ -1704,7 +1704,7 @@ def verify_preload(upload_id, language=None):
     return status
 
 
-@task
+@app.task
 @transaction.atomic
 def copy_to_characteristics(upload_id, language=None):
     """
@@ -1844,7 +1844,7 @@ def copy_to_characteristics(upload_id, language=None):
     return status
 
 
-@task
+@app.task
 def update_vacant_characteristics(upload_id, new_subj, language=None):
     """
     Update the values for the ComputedCharacteristics. This method
@@ -1930,7 +1930,7 @@ def update_vacant_characteristics(upload_id, new_subj, language=None):
     return status
 
 
-@task
+@app.task
 def renest_uploaded_subject(upload_id, language=None):
     """
     Renest all higher level geographies for the uploaded subject.
@@ -1995,7 +1995,7 @@ def renest_uploaded_subject(upload_id, language=None):
     return status
 
 
-@task
+@app.task
 def create_views_and_styles(upload_id, language=None):
     """
     Create the spatial views required for visualizing the subject data on the map.
@@ -2079,7 +2079,7 @@ def create_views_and_styles(upload_id, language=None):
     return status
 
 
-@task
+@app.task
 def clean_quarantined(upload_id, language=None):
     """
     Remove all temporary characteristics in the quarantine area for

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -1338,8 +1338,7 @@ class CalculatorReport:
                 name='%s_reports' % plan.legislative_body.name)
             html = display.render(plan, request, function_ids=function_ids)
         except Exception as ex:
-            logger.warn('Error creating calculator report')
-            logger.debug('Reason: %s', ex)
+            logger.exception('Error creating calculator report')
             html = _('Error creating calculator report.')
 
         # Add to report container template

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -32,7 +32,7 @@ from django_comments.models import Comment
 from django.contrib.sessions.models import Session
 from django.contrib.sites.models import Site
 from django.core.mail import send_mail, mail_admins, EmailMessage
-from django.template import loader, Context as DjangoContext
+from django.template import loader
 from django.db import connection, transaction
 from django.db.models import Sum, Min, Max, Avg
 from django.conf import settings
@@ -171,9 +171,10 @@ class DistrictIndexFile():
             error_subject = _("Problem importing your uploaded file.")
             success_subject = _("Upload and import plan confirmation.")
             admin_subject = _("Problem importing user uploaded file.")
-
-            context = DjangoContext({'user': owner, 'errors': list()})
-
+            context = {
+                'user': owner,
+                'errors': list()
+            }
         # Is this filename a zip archive?
         if filename.endswith('.zip'):
             try:
@@ -657,7 +658,7 @@ class DistrictIndexFile():
 
         # Add it as an attachment and send the email
         template = loader.get_template('submission.email')
-        context = DjangoContext({'user': user, 'plan': plan, 'post': post})
+        context = {'user': user, 'plan': plan, 'post': post}
         email = EmailMessage()
         email.subject = _(
             'Competition submission (user: %(username)s, planid: %(plan_id)d)'
@@ -675,7 +676,7 @@ class DistrictIndexFile():
         subject = _("Plan submitted successfully")
         user_email = post['email']
         template = loader.get_template('submitted.email')
-        context = DjangoContext({'user': user, 'plan': plan})
+        context = {'user': user, 'plan': plan}
         send_mail(
             subject,
             template.render(context),
@@ -1342,10 +1343,9 @@ class CalculatorReport:
             html = _('Error creating calculator report.')
 
         # Add to report container template
-        html = loader.get_template('report_panel_container.html').render(
-            DjangoContext({
-                'report_panels': html
-            }))
+        html = loader.get_template('report_panel_container.html').render({
+            'report_panels': html
+        })
 
         # Write it to file
         tempdir = settings.WEB_TEMP
@@ -2117,11 +2117,9 @@ def clean_quarantined(upload_id, language=None):
         logger.warn('Could not reset the is_valid flag on all plans.')
 
     status = {
-        'task_id':
-        None,
-        'success':
-        True,
-        'messages': [
+        'task_id':None,
+        'success':True,
+        'messages':[
             _('Upload complete. Subject "%(subject_name)s" added.') % {
                 'subject_name': upload.subject_name
             }

--- a/django/publicmapping/redistricting/tasks.py
+++ b/django/publicmapping/redistricting/tasks.py
@@ -1145,7 +1145,7 @@ class PlanReport:
                         planid)
             return
 
-        tempdir = settings.WEB_TEMP
+        tempdir = settings.REPORTS_ROOT
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
 
@@ -1240,7 +1240,7 @@ class PlanReport:
         except:
             return 'error'
 
-        tempdir = settings.WEB_TEMP
+        tempdir = settings.REPORTS_ROOT
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
 
@@ -1272,7 +1272,7 @@ class PlanReport:
         except:
             return 'error'
 
-        tempdir = settings.WEB_TEMP
+        tempdir = settings.REPORTS_ROOT
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
 
@@ -1348,7 +1348,7 @@ class CalculatorReport:
         })
 
         # Write it to file
-        tempdir = settings.WEB_TEMP
+        tempdir = settings.REPORTS_ROOT
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
         htmlfile = open(
@@ -1375,7 +1375,7 @@ class CalculatorReport:
         except:
             return 'error'
 
-        tempdir = settings.WEB_TEMP
+        tempdir = settings.REPORTS_ROOT
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
         pending_file = '%s/%s.pending' % (tempdir, filename)
@@ -1401,7 +1401,7 @@ class CalculatorReport:
         except:
             return 'error'
 
-        tempdir = settings.WEB_TEMP
+        tempdir = settings.REPORTS_ROOT
         filename = '%s_p%d_v%d_%s' % (plan.owner.username, plan.id,
                                       plan.version, stamp)
 

--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -45,7 +45,7 @@ from django.contrib.gis.gdal import *
 from django.contrib.gis.gdal.libgdal import lgdal
 from django.contrib.sites.models import Site
 from django.contrib import humanize
-from django.template import loader, Context as DjangoContext
+from django.template import loader
 from django.template.context_processors import csrf
 from django.utils import translation
 from django.utils.translation import ugettext as _, ungettext as _n
@@ -857,7 +857,7 @@ def printplan(request, planid):
 
         # render pg to a string
         t = loader.get_template('printplan.html')
-        page = t.render(DjangoContext(cfg))
+        page = t.render(cfg)
         result = StringIO.StringIO()
 
         # setting encoding='UTF-8' causes an exception. removing this for now,
@@ -1673,8 +1673,8 @@ def get_splits_report(request, planid):
         report = loader.get_template('split_report.html')
         html = ''
         for layer in layers:
-            my_context = {'extended': extended}
-            my_context.update(
+            calc_context = {'extended': extended}
+            calc_context.update(
                 plan.compute_splits(
                     layer, version=version, inverse=inverse,
                     extended=extended))
@@ -1685,8 +1685,7 @@ def get_splits_report(request, planid):
                 inverse=inverse,
                 include_counts=last_item)
             if community_info is not None:
-                my_context.update(community_info)
-            calc_context = DjangoContext(my_context)
+                calc_context.update(community_info)
             html += report.render(calc_context)
             if not last_item:
                 html += '<hr />'
@@ -2919,7 +2918,7 @@ def plan_feed(request):
         'width': width,
         'height': height
     }
-    xml = feed.render(DjangoContext(context))
+    xml = feed.render(context)
 
     return HttpResponse(xml, content_type='application/atom+xml')
 
@@ -2961,6 +2960,6 @@ def share_feed(request):
         'width': width,
         'height': height
     }
-    xml = feed.render(DjangoContext(context))
+    xml = feed.render(context)
 
     return HttpResponse(xml, content_type='application/atom+xml')

--- a/django/publicmapping/requirements.txt
+++ b/django/publicmapping/requirements.txt
@@ -3,9 +3,7 @@ ipython==5.5.0
 gevent==1.2.2
 Django==1.11.5
 psycopg2==2.7.3
-celery==3.0.15
-kombu==3.0.37
-django-celery==3.0.11
+celery[redis]==4.1.0
 django-redis==4.8.0
 django-rosetta==0.7.13
 django-staticfiles==1.2.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
 
   redis:
     image: redis:3.2-alpine
+    ports:
+     - '6379:6379'
 
   nginx:
     image: nginx:1.13.8-alpine
@@ -23,6 +25,7 @@ services:
       - ./nginx/:/etc/nginx/conf.d
       - ./django/publicmapping/static:/opt/static/
       - ./sld:/opt/sld/
+      - reports:/opt/reports
     depends_on:
       - django
 
@@ -34,6 +37,8 @@ services:
     volumes:
       - ./django/publicmapping/:/usr/src/app/
       - ./sld/:/opt/sld
+      - reports:/opt/reports
+    entrypoint: /usr/local/bin/gunicorn
     command:
       - "--workers=2"
       - "--timeout=60"
@@ -49,6 +54,22 @@ services:
       - redis:redis.internal.districtbuilder.com
       - geoserver:geoserver.internal.districtbuilder.com
 
+  celery:
+    build:
+      context: ./django/publicmapping
+    volumes:
+      - ./django/publicmapping/:/usr/src/app/
+      - reports:/opt/reports
+    entrypoint: /usr/local/bin/celery
+    command:
+      - "worker"
+      - "--app=publicmapping"
+      - "--uid=reporter"
+      - "--loglevel=INFO"
+    links:
+      - postgres:postgres.internal.districtbuilder.com
+      - redis:redis.internal.districtbuilder.com
+
   geoserver:
     build:
       context: ./geoserver
@@ -59,3 +80,6 @@ services:
       - "9091:8080"
     links:
       - postgres:postgres.internal.districtbuilder.com
+
+volumes:
+  reports:

--- a/nginx/django.conf
+++ b/nginx/django.conf
@@ -25,4 +25,8 @@ server {
   location /static/ {
     alias /opt/static/;
   }
+
+  location /reports/ {
+    alias /opt/reports/;
+  }
 }


### PR DESCRIPTION
## Overview

Fix reporting by upgrading Celery and creating a separate `celery` service.

### Notes

This PR cherry-picks some commits from https://github.com/PublicMapping/DistrictBuilder/pull/481 which was a much hackier way of implementing this same functionality.

## Testing Instructions

1. `vagrant up && vagrant ssh`
1. Within VM, `docker-compose build && docker-compose up`
1. Log in to DistrictBuilder as a guest
1. Go to the "Evaluate" tab (http://localhost:8080/districtmapping/plan/1/view/)
1. Click any report and then click "Create and Preview New Report"
1. See the report in the preview. Notice that the "Open Current Report in New Window" also works.
