### PR TITLE
Fix translations

### DIFF
--- a/django/publicmapping/redistricting/models.py
+++ b/django/publicmapping/redistricting/models.py
@@ -76,10 +76,9 @@ class BaseModel(models.Model):
         Initialize the message file cache.
         """
         super(BaseModel, self).__init__(*args, **kwargs)
-        lang = translation.get_language()
         # Hardcoding to avoid a bug in Django 1.8 get_language
         # (refer to https://github.com/django-parler/django-parler/issues/90)
-        lang = 'en'
+        lang = translation.get_language() or settings.LANGUAGE_CODE
         if not lang in I18N_CACHE:
             try:
                 path = os.path.join(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,18 @@ services:
     links:
       - postgres:postgres.internal.districtbuilder.com
 
+  languages:
+    build:
+      context: ./django/publicmapping
+    volumes:
+      - ./django/publicmapping/:/usr/src/app/
+    entrypoint: /usr/local/bin/python
+    command:
+      - "manage.py"
+      - "makelanguagefiles"
+    depends_on:
+      - django
+
 volumes:
   reports:
   data:


### PR DESCRIPTION
## Overview

This PR makes translations work without having to manually run any commands or do anything special besides use the app.

It does this via:
1. Make it so that compiled language files are generated whenever the `django` container is brought up
1. Fixes a bug whereby English was hardcoded

## Testing Instructions

 * `./scripts/server`
 * On main page, choose a different language (eg. Spanish)
 * Notice the translations change to Spanish
 * Bring the containers down and back up and refresh the page
 * Notice it's still in Spanish
