### PR TITLE
Remove pre-commit hook installation and setup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ Brief description of what this PR does, and why it is needed.
 ### Checklist
 
 - [ ] PR has a name that won't get you publicly shamed for vagueness
+- [ ] Files changed in the PR have been `yapf`-ed for style violations
 
 ### Demo
 

--- a/README.markdown
+++ b/README.markdown
@@ -98,3 +98,15 @@ Support
 More information about the application settings, configuration information, and run-time information is available in the PublicMapping/DistrictBuilder [wiki](https://github.com/PublicMapping/DistrictBuilder/wiki).
 
 Bug reports and feature requests can be reported to the PublicMapping/DistrictBuilder [issue tracker](https://github.com/PublicMapping/DistrictBuilder/issues).
+
+Development
+-----------
+
+For development and contribution to this repo, it is recommended to install [pre-commit](https://pre-commit.com/) and setup the `yapf` hook as follows:
+
+```bash
+$ pip install pre-commit
+$ pre-commit install
+```
+
+This will help with style of the Python code contributed to District Builder.

--- a/deployment/ansible/district-builder.yml
+++ b/deployment/ansible/district-builder.yml
@@ -10,4 +10,3 @@
     - { role: "azavea.python-security" }
     - { role: "district-builder.docker" }
     - { role: "district-builder.shellcheck" }
-    - { role: "district-builder.pre-commit" }

--- a/scripts/setup
+++ b/scripts/setup
@@ -23,9 +23,5 @@ then
         mkdir -p "${HOME}/.aws"
 
         vagrant up --provision
-
-        # Sets up pre-commit hooks to yapf new python files.
-        pre-commit install
-
     fi
 fi


### PR DESCRIPTION
## Overview

Remove pre-commit hook installation and setup. Add recommendation to use pre-commit hook. Add checkbox on PR template to remind contributors to `yapf` files.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Make sure setup script doesn't fail and doesn't try to install pre-commit hook