### PR TITLE
Break out config file loading into separate script

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,8 +28,19 @@ $ cp django/publicmapping/.env.sample django/publicmapping/.env
 $ ./scripts/setup
 $ vagrant ssh
 $ ./scripts/update
-$ ./scripts/configure
 ```
+
+If you want to get DistrictBuilder up and running quickly with demo data, you can then run
+```bash
+$ ./scripts/configure_va_demo
+```
+
+Otherwise, you'll need to provide your own shapefiles and config.xml file, and then run
+```bash
+$ ./scripts/load_configured_data
+```
+
+More detailed instructions on loading your own data can be found below.
 
 :zzz:
 
@@ -57,9 +68,9 @@ Ease of interacting with the configuration file is a planned area for future dev
 with docker installed. `vagrant ssh` gets you into the virtual machine so you can run commands.
 From there, running `./scripts/update` builds containers. The rest of the setup happens either
 directly or indirectly through a setup management command. To get started, run
-`./script/setup`, followed by `vagrant ssh`, followed by `./scripts/update`.
+`./scripts/setup`, followed by `vagrant ssh`, followed by `./scripts/update`.
  
-Then, run `./scripts/configure`. It is not fast. Currently, it takes several hours, with the exact
+Then, run `./scripts/configure_va_demo`. It is not fast. Currently, it takes several hours, with the exact
 time depending on hardware. We are working on ways to improve the speed of loading data.
 
 The script will do several things

--- a/deployment/scripts/load_configured_data.sh
+++ b/deployment/scripts/load_configured_data.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+if [[ -n "${DB_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+
+    echo -n \
+"Usage: $(basename "$0") [config file path]
+
+Configure the application with demo data loaded from /data/districtbuilder_data.zip
+"
+}
+
+function load_configured_data() {
+    echo "Unzipping shapefile"
+    docker-compose \
+        exec -T django \
+        unzip -o /data/districtbuilder_data.zip -d /data
+
+    echo "Loading shapefiles into database"
+    docker-compose \
+        exec -T django ./manage.py setup "${configPath}" -g0 -g1 -g2
+
+    echo "Nesting geolevels"
+    docker-compose \
+        exec -T django ./manage.py setup "${configPath}" -n0 -n1 -n2
+
+    echo "Creating template plans"
+    docker-compose \
+        exec -T django ./manage.py setup "${configPath}" -t
+
+    echo "Creating database views"
+    docker-compose \
+        exec -T django ./manage.py setup "${configPath}" --views
+
+    echo "Configuring geoserver"
+    docker-compose \
+        exec -T django ./manage.py setup "${configPath}" -G
+
+    echo "Creating translation files"
+    docker-compose \
+        exec -T django ./manage.py setup "${configPath}" -l
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        configPath=${1:-config/config.xml}
+        docker-compose up -d postgres django
+        load_configured_data
+    fi
+    exit
+fi
+

--- a/django/publicmapping/publicmapping/settings.py
+++ b/django/publicmapping/publicmapping/settings.py
@@ -15,6 +15,7 @@ NOTE: This settings file should not be changed!
 
 import os
 import logging.config
+import logging
 from . import REDIS_URL
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -232,4 +233,9 @@ REPORTS_ENABLED = 'CALC'
 # NOTE: Leave this at the end of the file!
 # These settings are generated based on config.xml
 # and allow for modifiying/overriding the default settings
-from publicmapping.config_settings import *
+try:
+    from publicmapping.config_settings import *
+except ImportError:
+    logger = logging.getLogger(__name__)
+    logger.error('Could not find config_settings; double-check the README for missed setup steps')
+    raise

--- a/scripts/configure_va_demo
+++ b/scripts/configure_va_demo
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+if [[ -n "${DB_DEBUG}" ]]; then
+    set -x
+fi
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function usage() {
+
+    echo -n \
+"Usage: $(basename "$0") [config.xml]
+
+Configure the application with demo data
+"
+}
+
+function fetch_dev_data() {
+    echo "Creating directory to download data into in django container"
+    docker-compose \
+        exec -T django mkdir -p /data
+
+    echo "Downloading shapefile"
+    docker-compose \
+        exec -T django \
+        wget -q \
+            -O /data/districtbuilder_data.zip \
+            https://s3.amazonaws.com/districtbuilderdata/VA_data.zip
+}
+
+function recreate_database() {
+    echo "Drop district_builder database"
+    docker-compose \
+        exec -T postgres gosu postgres dropdb --if-exists district_builder
+
+    echo "Create district_builder database"
+    docker-compose \
+        exec -T postgres gosu postgres createdb district_builder
+
+    echo "Running migrations"
+    docker-compose \
+        exec -T django ./manage.py migrate
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        configPath="config/${1:-config.xml}"
+        docker-compose up -d postgres django
+        #fetch_dev_data
+        #recreate_database
+        "${DIR}/load_configured_data" "${configPath}"
+    fi
+    exit
+fi

--- a/scripts/load_configured_data
+++ b/scripts/load_configured_data
@@ -8,40 +8,17 @@ fi
 function usage() {
 
     echo -n \
-"Usage: $(basename "$0") [config.xml]
+"Usage: $(basename "$0") [config file path]
 
-Configure the application with demo data
+Configure the application with demo data loaded from /data/districtbuilder_data.zip
 "
 }
 
-function load_dev_data() {
-    echo "Creating directory to download data into in django container"
-    docker-compose \
-        exec -T django mkdir -p /data
-
-    echo "Downloading shapefile"
-    docker-compose \
-        exec -T django \
-        wget -q \
-            -O /data/VA_data.zip \
-            https://s3.amazonaws.com/districtbuilderdata/VA_data.zip
-
+function load_configured_data() {
     echo "Unzipping shapefile"
     docker-compose \
         exec -T django \
-        unzip -o /data/VA_data.zip -d /data
-
-    echo "Drop district_builder database"
-    docker-compose \
-        exec -T postgres gosu postgres dropdb district_builder
-
-    echo "Create district_builder database"
-    docker-compose \
-        exec -T postgres gosu postgres createdb district_builder
-
-    echo "Running migrations"
-    docker-compose \
-        exec -T django ./manage.py migrate
+        unzip -o /data/districtbuilder_data.zip -d /data
 
     echo "Loading shapefiles into database"
     docker-compose \
@@ -66,7 +43,6 @@ function load_dev_data() {
     echo "Creating translation files"
     docker-compose \
         exec -T django ./manage.py setup "${configPath}" -l
-
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
@@ -75,9 +51,10 @@ then
     then
         usage
     else
-        configPath="config/${1:-config.xml}"
+        configPath=${1:-config/config.xml}
         docker-compose up -d postgres django
-        load_dev_data
+        load_configured_data
     fi
     exit
 fi
+

--- a/scripts/update
+++ b/scripts/update
@@ -9,15 +9,20 @@ function usage() {
 
     echo -n \
 "Usage: $(basename "$0")
-Setup external project dependencies.
+Setup project containers and database.
 "
 }
 
-
 function build_containers() {
+    echo "Building containers"
     docker-compose build
 }
 
+function run_migrations() {
+    echo "Running migrations"
+    docker-compose \
+        exec -T django ./manage.py migrate
+}
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
@@ -25,8 +30,9 @@ then
     then
         usage
     else
-        echo "Building containers"
         build_containers
+        docker-compose up -d postgres django
+        run_migrations
     fi
     exit
 fi

--- a/scripts/update
+++ b/scripts/update
@@ -24,6 +24,17 @@ function run_migrations() {
         exec -T django ./manage.py migrate
 }
 
+function write_settings() {
+    # Write config_settings to the filesystem so it doesn't get
+    # overwritten by docker-compose volume mounts
+    docker-compose run --rm --entrypoint "bash -c" django \
+        "python -m district_builder_config.generate_settings \
+            config/config.xsd \
+            config/config.xml \
+            publicmapping/config_settings.py"
+
+}
+
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
     if [ "${1:-}" = "--help" ]
@@ -31,6 +42,7 @@ then
         usage
     else
         build_containers
+        write_settings
         docker-compose up -d postgres django
         run_migrations
     fi


### PR DESCRIPTION
## Overview

This should make deployment easier by allowing data loading to happen
without dropping the database and running migrations.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] ~Files changed in the PR have been `yapf`-ed for style violations~

### Notes

I think this is what we discussed but I'm assigning extra reviewers to make sure this works for everyone.

## Testing Instructions

 * (Probably) comment out `clear_database` from `scripts/configure` if you already have data
 * `vagrant ssh` and run both `scripts/configure` and `scripts/load_configured_data`, and make sure they both work as expected.

@tnation14 isn't on the repo yet but I invited him and will add him as a reviewer when he confirms.
