### PR TITLE
Fix regression that broke reporting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - "${WEB_APP_PORT}"
     volumes:
       - ./django/publicmapping/:/usr/src/app/
-      - ./reports:/opt/reports
+      - reports:/opt/reports
     entrypoint: /usr/local/bin/gunicorn
     command:
       - "--workers=2"


### PR DESCRIPTION
## Overview

The shared volume must be used so that Django, Celery, and nginx can share static files.

## Testing Instructions

 * `./scripts/server`
 * Try to generate a report and notice it now succeeds
