### PR TITLE
Fix Leaderboard

### DIFF
--- a/django/publicmapping/redistricting/calculators.py
+++ b/django/publicmapping/redistricting/calculators.py
@@ -615,7 +615,7 @@ class PolsbyPopper(CalculatorBase):
     """
     Calculator for the Polsby-Popper measure of compactness.
 
-    The Polsby-Popper measure of campactness measures the area of a circle
+    The Polsby-Popper measure of compactness measures the area of a circle
     with the same perimeter as a district compared to area of the district.
 
     This calculator will calculate either the compactness score of a single

--- a/django/publicmapping/redistricting/models.py
+++ b/django/publicmapping/redistricting/models.py
@@ -4361,11 +4361,10 @@ class ComputedPlanScore(models.Model):
                 version=plan_version,
                 defaults=defaults)
 
-        except Exception, ex:
-            logger.info(
+        except:
+            logger.exception(
                 'Could not retrieve nor create ComputedPlanScore for plan %d',
                 plan.id)
-            logger.debug('Reason:', ex)
             return None
 
         if created:

--- a/django/publicmapping/redistricting/templates/leaderboard_panel_mine.html
+++ b/django/publicmapping/redistricting/templates/leaderboard_panel_mine.html
@@ -47,15 +47,15 @@
     </thead>
     <tbody>
       {% for planscore in planscores %}
-      {% if planscore.plan.owner.username == context.user.username %} 
+      {% if planscore.plan.owner.username == context.user.username %}
       <tr>
         <td>{{forloop.counter}}</td>
         <td>{{planscore.plan.owner.username}}</td>
         <td>
-          {% if planscore.plan.is_shared %} 
-          <a href="../../../plan/{{planscore.plan.id}}/view/" target="_blank">{{planscore.plan.name}}</a> 
-          {% else %} 
-          {{planscore.plan.name}} 
+          {% if planscore.plan.is_shared %}
+          <a href="../../../plan/{{planscore.plan.id}}/view/" target="_blank">{{planscore.plan.name}}</a>
+          {% else %}
+          {{planscore.plan.name}}
           {% endif %}
         </td>
         <td>{{planscore.score|safe}}</td>

--- a/django/publicmapping/redistricting/templates/leaderboard_panel_mine.html
+++ b/django/publicmapping/redistricting/templates/leaderboard_panel_mine.html
@@ -28,7 +28,7 @@
        Andrew Jennings, David Zwarg, Kenny Shepard
 
 {% endcomment %}
-{% load i18n %}
+{% load i18n static %}
 <div class="leaderboard_panel {% if position|divisibleby:'2' %}even{% else %}odd{% endif %} {{cssclass}}">
   <div class="leaderboard_title">
     <img src="{% static 'images/icon-help.png' %}" class="leaderboard divtip">

--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -372,7 +372,7 @@ def scoreplan(request, planid):
         try:
             score = ComputedPlanScore.compute(criteria.function, plan)
         except:
-            logger.debug(traceback.format_exc())
+            logger.exception('Failed to compute plan score')
 
         if not score or not score['value']:
             status['success'] = False


### PR DESCRIPTION
## Overview

Fix template for "My Ranked Plans", plus miscellaneous cleanup.

Also demonstrate that validation is working and is respecting `config.xml`.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Notes

When we were testing validation before, we were editing the wrong nodes in `config.xml`. It appears that only Geoserver cares about `<ScoreFunction id="a_congressional_population">`. The validation we care about for the `Equipopulation` calculator is `<ScoreFunction id="a_congress_plan_equipopulation_validation">`.

None of this is particularly clear. Seems like we might want to revisit configuration documentation for our own benefit/sanity as well as that of our future users.

### Demo

**Before**
![my_ranked_plans_broken](https://user-images.githubusercontent.com/2926237/36396454-520c1d6c-158c-11e8-8adf-53b7ae546dfe.png)

**After**
![my_ranked_plans_fixed](https://user-images.githubusercontent.com/2926237/36396455-5213e8b2-158c-11e8-8827-48b8cd209f50.png)

## Testing Instructions

 * `./scripts/server`
 * Log in (may need to register first)
 * Assuming you have the full data load, select "Congressional" plan, name the plan, and start drawing
 * Click "Share" tab
 * Click "Verify and Submit Plan to Leaderboards" button
 * Validation should fail with a message. Close the dialog.
  * In `config.xml`, go to the `ScoreFunction` node with an id of `a_congress_plan_equipopulation_validation`. Change the `min` argument to 0 and `max` to some huge number
 * Run `docker-compose exec -T django ./manage.py setup config/config.xml -f` (`force` flag is important so that the arguments are updated)
* Click "Verify and Submit Plan to Leaderboards" button again
* After the data loads, you should see your plan under "Top Ranked Users' Plans" in the leaderboard
* Click the "My Ranked Plans" tab and you should see the same plan listed

Closes #154978264
