### PR TITLE
Correct README to show .env file at root

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,9 +22,9 @@ Ansible 2.2
 ```bash
 $ # Copy config and make any necessary edits
 $ cp django/publicmapping/config/config.dist.xml django/publicmapping/config/config.xml
-$ # Copy .env file and add password/modify as necessary
+$ # Copy .env file and add passwords
 $ # NOTE: Leave MAP_SERVER_ADMIN_PASSWORD the same for now
-$ cp django/publicmapping/.env.sample django/publicmapping/.env
+$ cp .env.sample .env
 $ ./scripts/setup
 $ vagrant ssh
 $ ./scripts/update


### PR DESCRIPTION
## Overview

`.env` must be next to `docker-compose.yml` so that environment variables are templated in correctly.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * Notice where `docker-compose.yml` lives and that it makes sense to have `.env` next to it as per https://docs.docker.com/compose/environment-variables/#the-env-file
 * Alternatively, clone `DistrictBuilder` and get set up from scratch, following the README instructions to a 't' and notice that everything works :wink: 
