### PR TITLE
Fix sharing of plans

### DIFF
--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -298,7 +298,8 @@ def copyplan(request, planid):
     newname = p.name + " " + str(random.random())
     if (request.method == "POST"):
         newname = request.POST["name"][0:200]
-        shared = request.POST.get("shared", False)
+        shared = request.POST.get("shared",
+                                  False) and request.POST["shared"] == "true"
 
     plan_copy = Plan.objects.filter(
         name=newname, owner=request.user, legislative_body=p.legislative_body)


### PR DESCRIPTION
## Overview

Fix plan sharing.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * `./scripts/server`
 * Log in as registered user (not guest)
 * Choose a template plan assuming you have some loaded
 * Give it a name and start drawing
 * Click the "Share" tab
 * Give it a name and click "Save and Share"
 * Note that it works (success dialog is shown, newly generated link/plan works)
 * Click "Plan" tab
 * Click "My Plans" and select a plan
 * Choose "Copy and save selected plan", give it a name, and start drawing
 * Go back to "Plan" tab and notice that that plan is _not_ shared
