### PR TITLE
Add cibuild/cipublish to .travis.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
-.git/
+*
+!nginx/
+!django/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ deployment/ansible/roles/azavea.*
 sld
 geoserver/data_dir
 data
+config_settings.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 services:
   - docker
-
+env:
+  global:
+  - secure: IGCVQAaPbhBW47WUGtlOftOpPM7yIz3jk61niBmtF/ACIO9m8Y7KU2+Rl3MwM+4xGv4v0py9kpqAjk7FPCS6PCGA2pUpjMFuXiX7Dfh5Gsy1C0E/j2fvoTkOXkuterw0BcIwi7epymoY4aA8X0GinzuJ1B3sLJXqX8wfH49PSW0=
+  - secure: HgBnUcWY+L4XCzSBmg1JqCkMeN+5yoA23XTdTbJ0N5K8YXUpzP58FoYkwbhd5sjdnkcSr+2gnGzzxCQ9yxqiD0S78omjYPVurGntwGFdRjy9tATNpWbFqk9sViDX8ge+jx3+DYDIutXvZPZwrS4gkShHrByZrkQJvQTFBjwWkPQ=
 install:
-  - cp .env.sample .env
-  - sed -i 's/WEB_APP_PASSWORD=/WEB_APP_PASSWORD=travis/' .env
-  - sed -i 's/ADMIN_PASSWORD=/ADMIN_PASSWORD=admin/' .env
-  - sed -i 's/DATABASE_PASSWORD=/DATABASE_PASSWORD=district_builder/' .env
-  - sed -i 's/KEY_VALUE_STORE_PASSWORD=/KEY_VALUE_STORE_PASSWORD=redis/' .env
-  - sed -i 's/MAP_SERVER_ADMIN_PASSWORD=/MAP_SERVER_ADMIN_PASSWORD=geoserver/' .env
-  - cp django/publicmapping/config/config.dist.xml django/publicmapping/config/config.xml
-  - ./scripts/update
-
+- cp .env.sample .env
+- sed -i 's/WEB_APP_PASSWORD=/WEB_APP_PASSWORD=travis/' .env
+- sed -i 's/ADMIN_PASSWORD=/ADMIN_PASSWORD=admin/' .env
+- sed -i 's/DATABASE_PASSWORD=/DATABASE_PASSWORD=district_builder/' .env
+- sed -i 's/KEY_VALUE_STORE_PASSWORD=/KEY_VALUE_STORE_PASSWORD=redis/' .env
+- sed -i 's/MAP_SERVER_ADMIN_PASSWORD=/MAP_SERVER_ADMIN_PASSWORD=geoserver/' .env
+- cp django/publicmapping/config/config.dist.xml django/publicmapping/config/config.xml
+- "./scripts/update"
 script:
-  - ./scripts/test
+- "./scripts/cibuild"
+deploy:
+  - provider: script
+    script: "scripts/deploy"
+    on:
+      repo: PublicMapping/DistrictBuilder
+      branch: master

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,10 @@
+version: "3.3"
+services:
+  nginx:
+    image: quay.io/azavea/districtbuilder-nginx:${GIT_COMMIT}
+  django:
+    image: quay.io/azavea/districtbuilder-app:${GIT_COMMIT}
+  geoserver:
+    image: quay.io/azavea/districtbuilder-geoserver:${GIT_COMMIT}
+  terraform:
+    image: quay.io/azavea/terraform:0.10.8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "${WEB_APP_PORT}:${WEB_APP_PORT}"
     volumes:
       - ./django/publicmapping/static/:/opt/static/
-      - ./sld:/opt/sld/
+      - sld:/opt/sld/
       - reports:/opt/reports
     depends_on:
       - django
@@ -91,7 +91,7 @@ services:
     env_file:
       - .env
     volumes:
-      - sld/:/data/sld
+      - sld:/data/sld
     ports:
       - "${MAP_SERVER_PORT}:${WEB_APP_PORT}"
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,15 +25,17 @@ services:
   nginx:
     env_file:
       - .env
-    image: nginx:1.12
+    build:
+      context: .
+      dockerfile: nginx/Dockerfile
+      args:
+        WEB_APP_PORT: "${WEB_APP_PORT}"
     ports:
       - "${WEB_APP_PORT}:${WEB_APP_PORT}"
     volumes:
-      - ./nginx/:/etc/nginx/conf.d
-      - ./django/publicmapping/static:/opt/static/
-      - sld:/opt/sld/
+      - ./django/publicmapping/static/:/opt/static/
+      - ./sld:/opt/sld/
       - reports:/opt/reports
-    command: /bin/bash -c "envsubst < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
     depends_on:
       - django
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:1.12
+
+ARG WEB_APP_PORT
+
+COPY nginx/default.template /etc/nginx/conf.d/default.template
+COPY django/publicmapping/static/ /opt/static/
+
+RUN envsubst < /etc/nginx/conf.d/default.template \
+        > /etc/nginx/conf.d/default.conf \
+    && rm /etc/nginx/conf.d/default.template \
+    && chown -R nginx:nginx /opt/static

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+if [[ -n "${DB_DEBUG}" ]]; then
+    set -x
+fi
+
+if [[ -n "${TRAVIS_COMMIT}" ]]; then
+    GIT_COMMIT="${TRAVIS_COMMIT:0:7}"  
+else
+    GIT_COMMIT=$(git rev-parse --short HEAD)
+fi
+
+DIR="$(dirname "${0}")"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Build container images and run tests.
+"
+}
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+
+    # Run Tests
+    "${DIR}/../scripts/test"
+
+    # Build container images
+    GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+        -f docker-compose.yml \
+        -f docker-compose.ci.yml build \
+        nginx django geoserver
+    fi
+    exit
+fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+if [[ -n "${DB_DEBUG}" ]]; then
+    set -x
+fi
+
+if [[ -n "${TRAVIS_COMMIT}" ]]; then
+    GIT_COMMIT="${TRAVIS_COMMIT:0:7}"  
+else
+    GIT_COMMIT=$(git rev-parse --short HEAD)
+fi
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Deploy container images to remote repository.
+"
+}
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+
+    docker login -u "${QUAY_USER}" -p "${QUAY_PASSWORD}" quay.io
+
+    docker push "quay.io/azavea/districtbuilder-nginx:${GIT_COMMIT}"
+    docker push "quay.io/azavea/districtbuilder-app:${GIT_COMMIT}"
+    docker push "quay.io/azavea/districtbuilder-geoserver:${GIT_COMMIT}"
+
+    fi
+    exit
+fi

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+if [[ -n "${DB_DEBUG}" ]]; then
+    set -x
+fi
+
+DIR="$(dirname "${0}")"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Publish containers and run deployments.
+"
+}
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+
+    # Publish containers
+    "${DIR}/cipublish"
+
+    fi
+    exit
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -30,9 +30,9 @@ then
         if which shellcheck &>/dev/null; then
             echo "Linting STRTA scripts"
             find ./scripts -type f -print0 | xargs -0 -r shellcheck
-            docker-compose up -d postgres django
-            test_django_app
         fi
+        docker-compose up -d postgres django
+        test_django_app
     fi
     exit
 fi


### PR DESCRIPTION
## Overview

Adds STRTA to build containers and publish them to Quay from CI. This represents the first step in creating a Travis build/deploy pipeline.

- Added `Dockerfile` for `nginx`
-  Remove django tests from shellcheck conditional in scripts/test. Now `django` tests will always run, even if `shellcheck` isn't installed.
- add `scripts/cibuild` and `scripts/cipublish`
- Configure Travis to run STRTA build scripts
- Add quay.io login information to `.travis.yml`

### Checklist

- [ ] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * See [Travis build output](https://travis-ci.org/PublicMapping/DistrictBuilder/builds/346334572)
 * Images have successfully been deployed to quay.io. You should be able to pull them down locally.
```bash
docker pull quay.io/azavea/districtbuilder-nginx:1df1811
docker pull quay.io/azavea/districtbuilder-app:1df1811
docker pull quay.io/azavea/districtbuilder-geoserver:1df1811
```

Closes azavea/operations#172
