### PR TITLE
Fix extended splits reports

### DIFF
--- a/django/publicmapping/static/js/splitsreport.js
+++ b/django/publicmapping/static/js/splitsreport.js
@@ -92,7 +92,7 @@ splitsreport = function(options) {
                     waitDialog.remove();                        
                     $('<div/>').text(
                             gettext('Error encountered while retrieving splits report: ') + 
-                            '<div>' + textStatus + '</div>'
+                            xhr.status + ' - ' + error
                         ).dialog({
                         modal: true, autoOpen: true, title: gettext('Error'), resizable:false
                     });                

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - "--log-level=debug"
       - "--access-logfile=-"
       - "--error-logfile=-"
+      - "--timeout=300"
       - "-kgevent"
       - "publicmapping.wsgi"
     links:

--- a/nginx/default.template
+++ b/nginx/default.template
@@ -10,6 +10,9 @@ server {
   listen ${WEB_APP_PORT};
   server_name localhost;
 
+  # Long timeouts are necessary for extended split reports
+  proxy_read_timeout 300s;
+
   location / {
     proxy_pass http://web;
     client_max_body_size 20M;


### PR DESCRIPTION
## Overview

Generating an extended splits report for VA plans was broken. This fixes it and improves the error message for when it fails.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

**Improved Error Mesage**
![splits_report_improved_error_msg](https://user-images.githubusercontent.com/2926237/36740775-7247b354-1bb1-11e8-91c7-203cef79f76a.png)

**Extended Splits Report Generation Working**
![extended_splits_reports_working](https://user-images.githubusercontent.com/2926237/36740774-72327b4c-1bb1-11e8-85b9-4aefd4f817c5.png)

## Testing Instructions

 * `./scripts/update`
 * `./scripts/server`
 * Go to `localhost:8080`
 * Enter as a guest
 * Choose "Congressional" plan
 * View Plan
 * Click "Generate Splits Report" in "Map Tools" bar
 * Select some reference layers and click the "Extended Reports" checkbox at the bottom (this is important)
 * Notice that after > 60s (default timeout) it gives you a report

Closes #155400631
