### PR TITLE
Use correct attributes for Geoserver feature creation

### DIFF
--- a/django/publicmapping/redistricting/config.py
+++ b/django/publicmapping/redistricting/config.py
@@ -1252,26 +1252,25 @@ class SpatialUtils:
             return False
 
         # Create the feature types and their styles
-
-        geolevel_fields = [
-            x for x in Geolevel._meta.fields
-            if x.get_internal_type() != 'ForeignKey'
-        ]
-        geolevel_attrs = [{
-            'name': field.name,
-            'binding': SpatialUtils.get_binding(field)
-        } for field in geolevel_fields]
-
         subject_attrs = [
             {'name': 'name', 'binding': 'java.lang.String'},
-            {'name': 'geom', 'binding': 'java.lang.String'},
-            {'name': 'geolevel_id', 'binding': 'com.vividsolutions.jts.geom.MultiPolygon'},
+            {'name': 'geom', 'binding': 'com.vividsolutions.jts.geom.MultiPolygon'},
+            {'name': 'geolevel_id', 'binding': 'java.lang.Integer'},
             {'name': 'number', 'binding': 'java.lang.Double'},
             {'name': 'percentage', 'binding': 'java.lang.Double'},
         ]
 
         if self.create_featuretype(
-                'identify_geounit', attributes=geolevel_attrs):
+            'identify_geounit',
+            attributes=[
+                {'name': 'name', 'binding': 'java.lang.String'},
+                {'name': 'geolevel_id', 'binding': 'java.lang.Integer'},
+                {'name': 'geom', 'binding': 'com.vividsolutions.jts.geom.MultiPolygon'},
+                {'name': 'number', 'binding': 'java.lang.Double'},
+                {'name': 'percentage', 'binding': 'java.lang.Double'},
+                {'name': 'subject_id', 'binding': 'java.lang.Integer'}
+            ]
+        ):
             logger.debug('Created feature type "identify_geounit"')
         else:
             logger.warn('Could not create "identify_geounit" feature type')
@@ -1282,21 +1281,32 @@ class SpatialUtils:
                 continue
 
             if self.create_featuretype(
-                    'simple_%s' % geolevel.name, attributes=geolevel_attrs):
+                'simple_%s' % geolevel.name,
+                attributes=[
+                    {'name': 'name', 'binding': 'java.lang.String'},
+                    {'name': 'geolevel_id', 'binding': 'java.lang.Integer'},
+                    {'name': 'geom', 'binding': 'com.vividsolutions.jts.geom.MultiPolygon'}
+                ]
+            ):
                 logger.debug(
                     'Created "simple_%s" feature type' % geolevel.name)
             else:
                 logger.warn('Could not create "simple_%s" simple feature type'
                             % geolevel.name)
 
-            if self.create_featuretype(
-                    'simple_district_%s' % geolevel.name,
-                    attributes=geolevel_attrs):
+            simple_district_attrs = [
+                {'name': 'district_id', 'binding': 'java.lang.Integer'},
+                {'name': 'plan_id', 'binding': 'java.lang.Integer'},
+                {'name': 'legislative_body_id', 'binding': 'java.lang.Integer'},
+                {'name': 'geom', 'binding': 'com.vividsolutions.jts.geom.MultiPolygon'}
+            ]
+            if self.create_featuretype('simple_district_%s' % geolevel.name,
+                                       attributes=simple_district_attrs):
                 logger.debug('Created "simple_district_%s" feature type' %
                              geolevel.name)
             else:
                 logger.warn(
-                    'Colud not create "simple_district_%s" simple district feature type'
+                    'Could not create "simple_district_%s" simple district feature type'
                     % geolevel.name)
 
             all_subjects = Subject.objects.all().order_by('sort_key')
@@ -1309,7 +1319,7 @@ class SpatialUtils:
                         featuretype_name,
                         alias=get_featuretype_name(geolevel.name,
                                                    subject.name),
-                        attributes=geolevel_attrs):
+                        attributes=subject_attrs):
                     logger.debug(
                         'Created "%s" feature type' % featuretype_name)
                 else:
@@ -1352,7 +1362,7 @@ class SpatialUtils:
                         featuretype_name,
                         alias=get_featuretype_name(geolevel.name,
                                                    subject.name),
-                        attributes=geolevel_attrs):
+                        attributes=subject_attrs):
                     logger.debug(
                         'Created "%s" feature type' % featuretype_name)
                 else:
@@ -1449,7 +1459,7 @@ class SpatialUtils:
         if self.create_featuretype(
                 'simple_district',
                 alias='simple_district_%s' % geolevel.name,
-                attributes=geolevel_attrs):
+                attributes=simple_district_attrs):
             logger.debug('Created "simple_district" feature type')
         else:
             logger.warn('Could not create "simple_district" feature type')


### PR DESCRIPTION
## Overview

Fixes feature creation for Geoserver. Also fixes Reference Layers (perhaps). The main problem was that we were passing the wrong set of attributes to Geoserver when trying to create features based on our table views. The attributes for each feature must be a subset of the columns in the table or view. I resolved most of the issues by using the database console to inspect the views corresponding to each failed feature, and then changing that feature's attribute list to match.

### Checklist

- [X] PR has a name that won't get you publicly shamed for vagueness
- [X] Files changed in the PR have been `yapf`-ed for style violations

### Notes

- I'm not sure if the Reference Layer functionality is completely fixed; it doesn't result in angry red broken tiles anymore, but not all of the options seem to have a noticeable effect on the map. I didn't dig much further but this may need to be addressed if it's not expected functionality.
- This also significantly simplifies the code for clearing out the existing Geoserver configuration by using the `recurse` flag.

## Testing Instructions

From inside the VM
 * `./scripts/server`
 * `docker-compose exec django bash`
 * `./manage.py setup config/config.xml -G`
 * It should work without any error messages

Closes #155399854