### PR TITLE
Remove instance-specific text

### DIFF
--- a/django/publicmapping/publicmapping/templates/index.html
+++ b/django/publicmapping/publicmapping/templates/index.html
@@ -117,10 +117,7 @@
           </ul>
           <h3>{% trans "About this DistrictBuilder instance" %}</h3>
           <ul>
-            <li><a href="http://www.publicmapping.org/resources/country-resources/mexico">
-                {% trans "Mexico on the Public Mapping Project" %}</a></li>
-            <li><a href="/data/">
-                {% trans "Mexico data" %}</a></li>
+            <li><a href="#">{% trans "About this DistrictBuilder instance" %}</a></li>
           </ul>
         </div>
 
@@ -319,13 +316,6 @@
       {% endcomment %}
 
       <div id="sponsors">
-        <a target="_blank" class="logoRight" href="http://www.mozilla.com/?from=sfx&amp;uid=0&amp;t=306">
-          <img border="0" src="http://sfx-images.mozilla.org/affiliates/Buttons/firefox3/110x32_get_ffx.png"
-               alt="Spread Firefox Affiliate Button">
-        </a>
-        <p>
-            {% blocktrans with '<a target="_blank" href="http://www.mozilla.com/?from=sfx&amp;uid=0&amp;t=306">Mozilla Firefox</a>' as firefox_link %}We've designed the software to run on {{ firefox_link }} - a free web browser{% endblocktrans %}
-        </p>
       </div>
     </div>
 


### PR DESCRIPTION
## Overview

Removes text about the Mexico instance, and about Firefox sponsorship.

### Checklist

- [X] PR has a name that won't get you publicly shamed for vagueness
- ~[ ] Files changed in the PR have been `yapf`-ed for style violations~

### Demo

<img width="944" alt="screen shot 2018-02-27 at 2 24 10 pm" src="https://user-images.githubusercontent.com/447977/36749819-e7b06fc4-1bc9-11e8-9dab-d15cf244e640.png">

## Testing Instructions

 * `./scripts/server`
 * Confirm that there's no more text referring to Mexico or to Firefox on the homepage

Finishes #155376030
