### PR TITLE
Fix map transparency slider visibility on WebKit

### DIFF
--- a/django/publicmapping/static/css/core.css
+++ b/django/publicmapping/static/css/core.css
@@ -1605,13 +1605,11 @@ div#map_settings_content {
     position: absolute;
     top: 110px;
     right: 280px;
-	min-width: 140px;
+    min-width: 140px;
     background-color: #272727;
     color: #fff;
     border: 1px solid #666666;
     padding: 8px 11px;
-    opacity: 0.9;
-    filter: alpha(opacity=90);
     overflow-y: hidden;
     overflow-x: hidden;
     -moz-box-shadow: 2px 2px 2px #888888;


### PR DESCRIPTION
## Overview

The map transparency slider was invisible (except for its left border and padding, for some reason) on WebKit-based browsers (Chrome and Safari). This was due to (though I'm still fuzzy on the exact mechanics of _why_ this would happen) specifying `opacity: 0.9` on the element. Since `opacity: 0.9` barely results in a visible difference in the first place, I've just removed it.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- ~[ ] Files changed in the PR have been `yapf`-ed for style violations~

## Testing Instructions

 * Open the mapping page in Chrome or Safari, and also Firefox just to make sure.
 * Confirm you can see the transparency slider in all browsers :tada: 

Closes #155374778
