### PR TITLE
Download Geoserver from S3 bucket #155655892

### DIFF
--- a/geoserver/Dockerfile
+++ b/geoserver/Dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:8-jre-slim
 
 ENV GEOSERVER_VERSION 2.11.2
-ENV GEOSERVER_ZIP_URL http://sourceforge.net/projects/geoserver/files/GeoServer/${GEOSERVER_VERSION}/geoserver-${GEOSERVER_VERSION}-bin.zip
+ENV GEOSERVER_ZIP_URL https://s3.amazonaws.com/district-builder-global-artifacts-us-east-1/deps/geoserver-${GEOSERVER_VERSION}-bin.zip
 
 ENV GEOSERVER_DIR /usr/share
 ENV GEOSERVER_EXT_DIR $GEOSERVER_DIR/geoserver-$GEOSERVER_VERSION/webapps/geoserver/WEB-INF/lib


### PR DESCRIPTION
## Overview

The build was broken because downloading Geoserver from SourceForge was failing (SourceForge has been having a lot of issues the past week).

Now we download the version we want from our S3 bucket and it works :100: 

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * Check that the CI build has succeeded on this PR
 * Run `docker-compose build geoserver` and check that it succeeds

Closes #155655892
