### PR TITLE
Add shared tmp volume to process uploaded plans

### DIFF
--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -955,6 +955,7 @@ def uploadfile(request):
                 filename = '%s%s' % (dest.name, '.zip')
             else:
                 filename = dest.name
+            os.chmod(filename, 0664)
 
         except Exception as ex:
             logger.error('Could not save uploaded file')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - reports:/opt/reports
       - sld:/opt/sld
       - ./data/:/data/
+      - tmp:/tmp
     entrypoint: /usr/local/bin/gunicorn
     command:
       - "--workers=2"
@@ -76,6 +77,7 @@ services:
     volumes:
       - ./django/publicmapping/:/usr/src/app/
       - reports:/opt/reports
+      - tmp:/tmp
     entrypoint: /usr/local/bin/celery
     command:
       - "worker"
@@ -117,3 +119,4 @@ volumes:
   reports:
   data:
   sld:
+  tmp:


### PR DESCRIPTION
## Overview

The processing of plans after uploading is currently failing. This is because on upload, django stores the file in a `/tmp` directory in the django container. Celery expects the file to be in the `/tmp` directory in the celery container, but those directories were not shared volumes so it would be unable to find the file. This PR fixes this issue by allowing the two containers to share that volume. 

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * `vagrant ssh`
 * `./scripts/serve`
 * Log in 
 * Select a plan
 * Click "Download Index File" (bottom right)
 * Click "Upload Plan" left tab
 * Choose the index file you just downloaded
 * Choose legislative body
 * Give it a name and upload plan
 * Observe celery log with no error

```
celery_1     | [2018-03-13 15:17:33,565: INFO/MainProcess] Received task: redistricting.tasks.index2plan[21c17b0e-4b27-42b0-87fa-90b893b20216]  
```

 * Wait about 6 minutes until the logs show celery succeeded in processing the file

```
celery_1     | [2018-03-13 15:23:38,947: INFO/ForkPoolWorker-2] Task redistricting.tasks.index2plan[21c17b0e-4b27-42b0-87fa-90b893b20216] succeeded in 365.378699927s: None
```

 * Click "My Plans" on the left tab
 * Verify that the plan you uploaded appears there
