### PR TITLE
Make GeoServer config persistent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
     env_file:
       - .env
     volumes:
+      - data:/data
       - sld:/data/sld
     ports:
       - "${MAP_SERVER_PORT}:${WEB_APP_PORT}"


### PR DESCRIPTION
## Overview

Previously, only one subfolder of GEOSERVER_DATA_DIR (`/data/sld`) was persisted using a Docker volume mount. As a result, anytime GeoServer was removed and re-created, the remaining configuration (reset password, stored layers) were lost. This commit makes the entire GEOSERVER_DATA_DIR persistent by using a Docker volume.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] ~Files changed in the PR have been `yapf`-ed for style violations~

### Demo
N/A

### Notes
N/A

## Testing Instructions
- See azavea/district-builder-dtl-pa/pull/23

