### PR TITLE
Represent Gravelius scores as decimal number

### DIFF
--- a/django/publicmapping/redistricting/calculators.py
+++ b/django/publicmapping/redistricting/calculators.py
@@ -173,6 +173,20 @@ class CalculatorBase(object):
         c = Context({'percentage': self.result['value'] * 100})
         return t.render(c)
 
+    def decimal(self, span=False):
+        """
+        Return the calculator's result value as a properly localized
+        decimal number
+
+        @return: A string representing the result as a decimal
+        """
+        if span:
+            t = Template('<span>{{ value|floatformat:2 }}</span>')
+        else:
+            t = Template('{{ value|floatformat:2 }}')
+        c = Context({'value': self.result['value']})
+        return t.render(c)
+
     def get_value(self, argument, district=None):
         """
         Get the value of an argument if it is a literal or a subject.
@@ -752,12 +766,12 @@ class Gravelius(CalculatorBase):
     def html(self):
         """
         Generate an HTML representation of the compactness score. This
-        is represented as a percentage or "n/a"
+        is represented as a decimal value or "n/a"
 
-        @return: A number formatted similar to "1.00%", or "n/a"
+        @return: A number formatted similar to "1.00", or "n/a"
         """
         if self.result is not None and 'value' in self.result:
-            return '<span>%s</span>' % self.percentage()
+            return self.decimal()
         else:
             return _("n/a")
 

--- a/django/publicmapping/redistricting/calculators.py
+++ b/django/publicmapping/redistricting/calculators.py
@@ -771,7 +771,7 @@ class Gravelius(CalculatorBase):
         @return: A number formatted similar to "1.00", or "n/a"
         """
         if self.result is not None and 'value' in self.result:
-            return self.decimal()
+            return '<span>%s</span>' % self.decimal()
         else:
             return _("n/a")
 


### PR DESCRIPTION
## Overview
During RRP we discussed the fact that, because of circles' nature as having the optimal perimeter-to-area shape, Gravelius scores are almost certain to be greater than 1, causing them to have a potentially confusing representation, like "Compactness: 184%", which has misleading implications about the district somehow being more compact than some theoretical maximum. The decision was to represent them as a decimal value, so instead it would be shown as "Compactness: 1.84".

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Demo
![screen shot 2018-12-14 at 11 58 09 am](https://user-images.githubusercontent.com/1032849/50016562-8b7a6900-ff97-11e8-8294-d17b25ad8713.png)

## Testing Instructions
- Enable the Gravelius calculator
  - (This was done locally by renaming the Gravelius calculator class to PolsbyPopper, then changing the map to cause the statistics to be recalculated)
- Gravelius scores for a map should be displayed as a decimal number with 2 significant digits

Closes [PT162648523](https://www.pivotaltracker.com/story/show/162648523)
